### PR TITLE
Download time of response body is not included in Response.elapsed

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -423,4 +423,12 @@ class HTTPAdapter(BaseAdapter):
             else:
                 raise
 
-        return self.build_response(request, resp)
+        r = self.build_response(request, resp)
+
+        if not stream and not r.is_redirect:
+            # Consume response body unless the response is to be streamed, and unless 
+            # this is a redirect response, in which case it will be consumed in 
+            # SessionRedirectMixin.resolve_redirects()
+            r.content
+
+        return r

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -590,9 +590,6 @@ class Session(SessionRedirectMixin):
             r = history.pop()
             r.history = history
 
-        if not stream:
-            r.content
-
         return r
 
     def merge_environment_settings(self, url, proxies, stream, verify, cert):

--- a/test_requests.py
+++ b/test_requests.py
@@ -719,6 +719,12 @@ class RequestsTestCase(unittest.TestCase):
         total_seconds = ((td.microseconds + (td.seconds + td.days * 24 * 3600)
                          * 10**6) / 10**6)
         assert total_seconds > 0.0
+    
+    def test_time_elapsed_streaming_response(self):
+        # check that the download time of the whole body is included in 
+        # response.elapsed when stream=False
+        r = requests.get(httpbin('drip') + "?numbytes=512&duration=1&code=200", stream=False)
+        self.assertGreater(r.elapsed.total_seconds(), 0.9)
 
     def test_response_is_iterable(self):
         r = requests.Response()

--- a/test_requests.py
+++ b/test_requests.py
@@ -724,7 +724,7 @@ class RequestsTestCase(unittest.TestCase):
         # check that the download time of the whole body is included in 
         # response.elapsed when stream=False
         r = requests.get(httpbin('drip') + "?numbytes=512&duration=1&code=200", stream=False)
-        self.assertGreater(r.elapsed.total_seconds(), 0.9)
+        self.assertTrue(r.elapsed.total_seconds() > 0.9, "%r not greater than 0.9" % r.elapsed.total_seconds())
 
     def test_response_is_iterable(self):
         r = requests.Response()

--- a/test_requests.py
+++ b/test_requests.py
@@ -724,7 +724,8 @@ class RequestsTestCase(unittest.TestCase):
         # check that the download time of the whole body is included in 
         # response.elapsed when stream=False
         r = requests.get(httpbin('drip') + "?numbytes=512&duration=1&code=200", stream=False)
-        assert r.elapsed.total_seconds() > 0.9
+        seconds = r.elapsed.microseconds / float(10**6) + r.elapsed.seconds
+        assert seconds > 0.9
 
     def test_response_is_iterable(self):
         r = requests.Response()

--- a/test_requests.py
+++ b/test_requests.py
@@ -724,7 +724,7 @@ class RequestsTestCase(unittest.TestCase):
         # check that the download time of the whole body is included in 
         # response.elapsed when stream=False
         r = requests.get(httpbin('drip') + "?numbytes=512&duration=1&code=200", stream=False)
-        self.assertTrue(r.elapsed.total_seconds() > 0.9, "%r not greater than 0.9" % r.elapsed.total_seconds())
+        assert r.elapsed.total_seconds() > 0.9
 
     def test_response_is_iterable(self):
         r = requests.Response()


### PR DESCRIPTION
When doing a request with stream=False, to an endpoint that responds with a streaming/chunked response, the download time of the response body is not included in the Response.elapsed timedelta.

This pull request adds a test for this that currently fails.

In Requests 2.2 the behaviour was different, and this test passes. If the current behaviour is the intended, I guess one could just modify the test in this pull request to reflect the expected behaviour.
