### PR TITLE
Copy pip's import machinery wholesale

### DIFF
--- a/requests/packages/__init__.py
+++ b/requests/packages/__init__.py
@@ -1,3 +1,80 @@
+"""
+pip._vendor is for vendoring dependencies of pip to prevent needing pip to
+depend on something external.
+
+Files inside of pip._vendor should be considered immutable and should only be
+updated to versions from upstream.
+"""
 from __future__ import absolute_import
 
-from . import urllib3
+import sys
+
+
+class VendorAlias(object):
+
+    def __init__(self):
+        self._vendor_name = __name__
+        self._vendor_pkg = self._vendor_name + "."
+
+    def find_module(self, fullname, path=None):
+        if fullname.startswith(self._vendor_pkg):
+            return self
+
+    def load_module(self, name):
+        # Ensure that this only works for the vendored name
+        if not name.startswith(self._vendor_pkg):
+            raise ImportError(
+                "Cannot import %s, must be a subpackage of '%s'." % (
+                    name, self._vendor_name,
+                )
+            )
+
+        # Check to see if we already have this item in sys.modules, if we do
+        # then simply return that.
+        if name in sys.modules:
+            return sys.modules[name]
+
+        # Check to see if we can import the vendor name
+        try:
+            # We do this dance here because we want to try and import this
+            # module without hitting a recursion error because of a bunch of
+            # VendorAlias instances on sys.meta_path
+            real_meta_path = sys.meta_path[:]
+            try:
+                sys.meta_path = [
+                    m for m in sys.meta_path
+                    if not isinstance(m, VendorAlias)
+                ]
+                __import__(name)
+                module = sys.modules[name]
+            finally:
+                # Re-add any additions to sys.meta_path that were made while
+                # during the import we just did, otherwise things like
+                # pip._vendor.six.moves will fail.
+                for m in sys.meta_path:
+                    if m not in real_meta_path:
+                        real_meta_path.append(m)
+
+                # Restore sys.meta_path with any new items.
+                sys.meta_path = real_meta_path
+        except ImportError:
+            # We can't import the vendor name, so we'll try to import the
+            # "real" name.
+            real_name = name[len(self._vendor_pkg):]
+            try:
+                __import__(real_name)
+                module = sys.modules[real_name]
+            except ImportError:
+                raise ImportError("No module named '%s'" % (name,))
+
+        # If we've gotten here we've found the module we're looking for, either
+        # as part of our vendored package, or as the real name, so we'll add
+        # it to sys.modules as the vendored name so that we don't have to do
+        # the lookup again.
+        sys.modules[name] = module
+
+        # Finally, return the loaded module
+        return module
+
+
+sys.meta_path.append(VendorAlias())

--- a/requests/packages/__init__.py
+++ b/requests/packages/__init__.py
@@ -1,9 +1,24 @@
 """
-pip._vendor is for vendoring dependencies of pip to prevent needing pip to
-depend on something external.
+Copyright (c) Donald Stufft, pip, and individual contributors
 
-Files inside of pip._vendor should be considered immutable and should only be
-updated to versions from upstream.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
@@ -50,7 +65,7 @@ class VendorAlias(object):
             finally:
                 # Re-add any additions to sys.meta_path that were made while
                 # during the import we just did, otherwise things like
-                # pip._vendor.six.moves will fail.
+                # requests.packages.urllib3.poolmanager will fail.
                 for m in sys.meta_path:
                     if m not in real_meta_path:
                         real_meta_path.append(m)


### PR DESCRIPTION
Fedora and Debian have both recently added symlinks to their distributions of requests so people can do `from requests.packages import urllib3` but they seem to still rewrite our import statements. So the following situation is possible:

- User registers adapter for custom scheme

- User does the following:

    ```python
    from requests.packages.urllib3 import poolmanager

    poolmanager.pool_classes_by_scheme['glance+https'] = HTTPSConectionPool
    ```

- When they do `s.get('glance+https://...')` they see a `KeyError` because the urllib3 we're using in requests is not the one they've imported (according to `sys.modules`).

Pip works around this with the copied machinery. The tests seem to work just fine for me. I still need to test this with our vendored packages removed and urllib3/chardet installed separately.

/cc @dstufft @eriolv @ralphbean 