### PR TITLE
Replace n-dash in HISTORY to workaround pip bug

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -103,7 +103,7 @@ Release History
 - Support for connect timeouts! Timeout now accepts a tuple (connect, read) which is used to set individual connect and read timeouts.
 - Allow copying of PreparedRequests without headers/cookies.
 - Updated bundled urllib3 version.
-- Refactored settings loading from environment — new `Session.merge_environment_settings`.
+- Refactored settings loading from environment -- new `Session.merge_environment_settings`.
 - Handle socket errors in iter_content.
 
 


### PR DESCRIPTION
There exists a problem (maybe a bug?) in pip when using a locale like `LC_ALL=C` (which is commonly used by CI environments and system configuration tools such as Puppet), where the PKG-INFO file is decoded using ascii, raising a UnicodeDecodeError when PKG-INFO contains non-ASCII characters (such as the n-dash removed by this commit):

    Downloading/unpacking requests from https://pypi.python.org/packages/source/r/requests/requests-2.5.1.tar.gz
      Downloading requests-2.5.1.tar.gz (443Kb): 443Kb downloaded
      Running setup.py egg_info for package requests
    
    Exception:
    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/pip/basecommand.py", line 104, in main
        status = self.run(options, args)
      File "/usr/lib/python3/dist-packages/pip/commands/install.py", line 245, in run
        requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
      File "/usr/lib/python3/dist-packages/pip/req.py", line 1014, in prepare_files
        req_to_install.assert_source_matches_version()
      File "/usr/lib/python3/dist-packages/pip/req.py", line 359, in assert_source_matches_version
        version = self.installed_version
      File "/usr/lib/python3/dist-packages/pip/req.py", line 351, in installed_version
        return self.pkg_info()['version']
      File "/usr/lib/python3/dist-packages/pip/req.py", line 318, in pkg_info
        data = self.egg_info_data('PKG-INFO')
      File "/usr/lib/python3/dist-packages/pip/req.py", line 261, in egg_info_data
        data = fp.read()
      File "/usr/lib/python3.2/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8161: ordinal not in range(128)

There are some existing issues for pip:

* pypa/pip#1233
* pypa/pip#761

Other projects have had the same issue occur; there is some useful discussion in these issues as well:

* cleder/fastkml#9
* gabrielfalcao/HTTPretty#108
* rbarrois/factory_boy#118

I know this isn't really a problem with requests (and should probably be addressed ultimately in pip), but I think replacing this character in HISTORY would be a pain-free and pragmatic way to help developers and system administrators, especially given the inactivity on the pip bug reports.

Many thanks!