### PR TITLE
Docs fixed

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -169,6 +169,21 @@ download, the above is the preferred and recommended way to retrieve the
 content.
 
 
+Custom Headers
+--------------
+
+If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
+``headers`` parameter.
+
+For example, we didn't specify our content-type in the previous example::
+
+    >>> import json
+    >>> url = 'https://api.github.com/some/endpoint'
+    >>> headers = {'user-agent': 'Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.7.5) Gecko/20041109 Firefox/1.0'}
+
+    >>> r = requests.post(url, headers=headers)
+
+
 More complicated POST requests
 ------------------------------
 
@@ -198,22 +213,6 @@ For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
     >>> payload = {'some': 'data'}
 
     >>> r = requests.post(url, data=json.dumps(payload))
-
-
-Custom Headers
---------------
-
-If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
-``headers`` parameter.
-
-For example, we didn't specify our content-type in the previous example::
-
-    >>> import json
-    >>> url = 'https://api.github.com/some/endpoint'
-    >>> payload = {'some': 'data'}
-    >>> headers = {'content-type': 'application/json'}
-
-    >>> r = requests.post(url, data=json.dumps(payload), headers=headers)
 
 
 POST a Multipart-Encoded File

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -168,6 +168,7 @@ have to handle when using ``Response.raw`` directly. When streaming a
 download, the above is the preferred and recommended way to retrieve the
 content.
 
+
 More complicated POST requests
 ------------------------------
 
@@ -197,6 +198,22 @@ For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
     >>> payload = {'some': 'data'}
 
     >>> r = requests.post(url, data=json.dumps(payload))
+
+
+Custom Headers
+--------------
+
+If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
+``headers`` parameter.
+
+For example, we didn't specify our content-type in the previous example::
+
+    >>> import json
+    >>> url = 'https://api.github.com/some/endpoint'
+    >>> payload = {'some': 'data'}
+    >>> headers = {'content-type': 'application/json'}
+
+    >>> r = requests.post(url, data=json.dumps(payload), headers=headers)
 
 
 POST a Multipart-Encoded File
@@ -255,23 +272,6 @@ support this, but there is a separate package which does -
 
 For sending multiple files in one request refer to the :ref:`advanced <advanced>`
 section.
-
-
-Custom Headers
---------------
-
-If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
-``headers`` parameter.
-
-For example, we didn't specify our content-type in the previous example::
-
-    >>> import json
-    >>> url = 'https://api.github.com/some/endpoint'
-    >>> payload = {'some': 'data'}
-    >>> headers = {'content-type': 'application/json'}
-
-    >>> r = requests.post(url, data=json.dumps(payload), headers=headers)
-
 
 
 Response Status Codes

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -177,7 +177,6 @@ If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
 
 For example, we didn't specify our content-type in the previous example::
 
-    >>> import json
     >>> url = 'https://api.github.com/some/endpoint'
     >>> headers = {'user-agent': 'Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.7.5) Gecko/20041109 Firefox/1.0'}
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -168,23 +168,6 @@ have to handle when using ``Response.raw`` directly. When streaming a
 download, the above is the preferred and recommended way to retrieve the
 content.
 
-
-Custom Headers
---------------
-
-If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
-``headers`` parameter.
-
-For example, we didn't specify our content-type in the previous example::
-
-    >>> import json
-    >>> url = 'https://api.github.com/some/endpoint'
-    >>> payload = {'some': 'data'}
-    >>> headers = {'content-type': 'application/json'}
-
-    >>> r = requests.post(url, data=json.dumps(payload), headers=headers)
-
-
 More complicated POST requests
 ------------------------------
 
@@ -272,6 +255,23 @@ support this, but there is a separate package which does -
 
 For sending multiple files in one request refer to the :ref:`advanced <advanced>`
 section.
+
+
+Custom Headers
+--------------
+
+If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
+``headers`` parameter.
+
+For example, we didn't specify our content-type in the previous example::
+
+    >>> import json
+    >>> url = 'https://api.github.com/some/endpoint'
+    >>> payload = {'some': 'data'}
+    >>> headers = {'content-type': 'application/json'}
+
+    >>> r = requests.post(url, data=json.dumps(payload), headers=headers)
+
 
 
 Response Status Codes

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -175,7 +175,7 @@ Custom Headers
 If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
 ``headers`` parameter.
 
-For example, we didn't specify our content-type in the previous example::
+For example, we can specify custom user agent like this::
 
     >>> url = 'https://api.github.com/some/endpoint'
     >>> headers = {'user-agent': 'Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.7.5) Gecko/20041109 Firefox/1.0'}


### PR DESCRIPTION
Moved "Custom Headers" part after "More complicated POST requests" and before "POST a Multipart-Encoded File" in quickstart doc for adding headers is mentioned in the last one.