### PR TITLE
Update support documentation to be more accurate

### DIFF
--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -32,7 +32,7 @@ Our PGP Key fingerprints are:
 
 - 0161 BB7E B208 B5E0 4FDC  9F81 D9DA 0A04 9113 F853 (@sigmavirus24)
 
-- (@lukasa)
+- 90DC AE40 FEA7 4B14 9B70  662D F25F 2144 EEC1 373D (@lukasa)
 
 If English is not your first language, please try to describe the problem and
 its impact to the best of your ability. For greater detail, please use your native

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -5,12 +5,27 @@ Support
 
 If you have questions or issues about Requests, there are several options:
 
+StackOverflow
+-------------
+
+If your question does not contain sensitive (possibly proprietary)
+information or can be properly anonymized, please ask a question on
+`StackOverflow <https://stackoverflow.com/questions/tagged/python-requests>`_
+and use the tag ``python-requests``.
+
 Send a Tweet
 ------------
 
 If your question is less than 140 characters, feel free to send a tweet to
-`@kennethreitz <http://twitter.com/kennethreitz>`_.
+`@kennethreitz <https://twitter.com/kennethreitz>`_ or
+`@sigmavirus24 <https://twitter.com/sigmavirus24>`_.
 
+Vulnerability Disclosure
+------------------------
+
+If you think you have found a potential security vulnerability in requests,
+please email `sigmavirus24 <mailto:graffatcolmingov@gmail.com>`_ and
+`Lukasa <mailto:cory@lukasa.co.uk>`_ directly. **Do not file a public issue.**
 
 File an Issue
 -------------
@@ -34,4 +49,9 @@ IRC
 The official Freenode channel for Requests is
 `#python-requests <irc://irc.freenode.net/python-requests>`_
 
-I'm also available as **kennethreitz** on Freenode.
+The core developers of requests are on IRC throughout the day.
+You can find them in ``#python-requests`` as:
+
+- kennethreitz
+- lukasa
+- sigmavirus24

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -29,7 +29,7 @@ please email `sigmavirus24 <mailto:graffatcolmingov@gmail.com>`_ and
 `Lukasa <mailto:cory@lukasa.co.uk>`_ directly. **Do not file a public issue.**
 
 If English is not your first language, please try to describe the problem and
-its impact to the best of your ability. For greater detail please use your native
+its impact to the best of your ability. For greater detail, please use your native
 language and we will try our best to translate it using online services. Please
 also include the code you used to find the problem and the shortest amount of code
 necessar to reproduce it. Please do not disclose this to anyone else. We will

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -30,12 +30,26 @@ please email `sigmavirus24 <mailto:graffatcolmingov@gmail.com>`_ and
 
 If English is not your first language, please try to describe the problem and
 its impact to the best of your ability. For greater detail, please use your native
-language and we will try our best to translate it using online services. Please
-also include the code you used to find the problem and the shortest amount of code
-necessar to reproduce it. Please do not disclose this to anyone else. We will
-retrieve a CVE identifier if necessary and give you full credit under whatever
-name or alias you provide. We will respect your privacy and will only publicize
-your involvement if you grant us permission.
+language and we will try our best to translate it using online services.
+
+Please also include the code you used to find the problem and the shortest amount
+of code necessary to reproduce it.
+
+Please do not disclose this to anyone else. We will retrieve a CVE identifier if
+necessary and give you full credit under whatever name or alias you provide.
+We will only request an identifier when we have a fix and can publish it in a release.
+
+We will respect your privacy and will only publicize your involvement if you grant
+us permission.
+
+Previous CVEs
+~~~~~~~~~~~~~
+
+- Fixed in 2.3.0
+
+  - `CVE 2014-1829 <http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2014-1829>`_
+
+  - `CVE 2014-1830 <http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2014-1830>`_
 
 File an Issue
 -------------

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -28,6 +28,12 @@ If you think you have found a potential security vulnerability in requests,
 please email `sigmavirus24 <mailto:graffatcolmingov@gmail.com>`_ and
 `Lukasa <mailto:cory@lukasa.co.uk>`_ directly. **Do not file a public issue.**
 
+Our PGP Key fingerprints are:
+
+- 0161 BB7E B208 B5E0 4FDC  9F81 D9DA 0A04 9113 F853 (@sigmavirus24)
+
+- (@lukasa)
+
 If English is not your first language, please try to describe the problem and
 its impact to the best of your ability. For greater detail, please use your native
 language and we will try our best to translate it using online services.

--- a/docs/community/support.rst
+++ b/docs/community/support.rst
@@ -17,8 +17,9 @@ Send a Tweet
 ------------
 
 If your question is less than 140 characters, feel free to send a tweet to
-`@kennethreitz <https://twitter.com/kennethreitz>`_ or
-`@sigmavirus24 <https://twitter.com/sigmavirus24>`_.
+`@kennethreitz <https://twitter.com/kennethreitz>`_,
+`@sigmavirus24 <https://twitter.com/sigmavirus24>`_, or
+`@lukasaoz <https://twitter.com/lukasaoz>`_.
 
 Vulnerability Disclosure
 ------------------------
@@ -26,6 +27,15 @@ Vulnerability Disclosure
 If you think you have found a potential security vulnerability in requests,
 please email `sigmavirus24 <mailto:graffatcolmingov@gmail.com>`_ and
 `Lukasa <mailto:cory@lukasa.co.uk>`_ directly. **Do not file a public issue.**
+
+If English is not your first language, please try to describe the problem and
+its impact to the best of your ability. For greater detail please use your native
+language and we will try our best to translate it using online services. Please
+also include the code you used to find the problem and the shortest amount of code
+necessar to reproduce it. Please do not disclose this to anyone else. We will
+retrieve a CVE identifier if necessary and give you full credit under whatever
+name or alias you provide. We will respect your privacy and will only publicize
+your involvement if you grant us permission.
 
 File an Issue
 -------------


### PR DESCRIPTION
We were missing instructions to report security vulnerabilities,
and all of the documentation referred to Kenneth as the only
source of support. We were also missing a link to StackOverflow.