### PR TITLE
Fixes problems with iter_lines when the delimiter is split

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -778,6 +778,46 @@ class RequestsTestCase(unittest.TestCase):
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
+    def test_response_lines(self):
+        """
+        iter_lines should be able to handle data dribbling in which might
+        not be lined up ideally.
+        """
+        mock_chunks = [
+            'This \r\n',
+            '',
+            'is\r',
+            '\n',
+            'a',
+            ' ',
+            '',
+            '',
+            'test.',
+            '\r',
+            '\n',
+            'end.',
+        ]
+
+        def mock_iter_content(*args, **kwargs):
+            '''Fake difficult data.'''
+            for chunk in mock_chunks:
+                yield chunk
+
+        r = requests.Response()
+        r._content_consumed = True
+        r.iter_content = mock_iter_content
+
+        assert list(r.iter_lines(delimiter='\r\n')) == \
+            ''.join(mock_chunks).split('\r\n')
+
+        # This test can't pass because '\n' by itself is a single line-end, but
+        # '\r\n' is also a single line-end
+        assert not (list(r.iter_lines()) == ''.join(mock_chunks).splitlines())
+
+        # However, this should pass if everything is '\r'
+        mock_chunks = [chunk.replace('\n', '\r') for chunk in mock_chunks]
+        assert list(r.iter_lines()) == ''.join(mock_chunks).splitlines()
+
     def test_request_and_response_are_pickleable(self):
         r = requests.get(httpbin('get'))
 


### PR DESCRIPTION
I ran into this problem today where my data would randomly have additional null strings from iter_lines.  I added a test to show the issue, then fixed it.

The only weirdness might be when no data comes back, how should iter_lines behave?  Should there be a single yield of a null string, or should it just return without yielding anything?  This edit performs the latter.
