### PR TITLE
add a timeout value to connection_error_invalid_port test to accelerate failure

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -309,7 +309,7 @@ class RequestsTestCase(unittest.TestCase):
     def test_connection_error_invalid_port(self):
         """Connecting to an invalid port should raise a ConnectionError"""
         with pytest.raises(ConnectionError):
-            requests.get("http://httpbin.org:1")
+            requests.get("http://httpbin.org:1", timeout=1)
 
     def test_LocationParseError(self):
         """Inputing a URL that cannot be parsed should raise an InvalidURL error"""


### PR DESCRIPTION
As mentioned here https://github.com/kennethreitz/requests/pull/2436 , one of the tests seemed like it was hanging.   In fact, the test was just (correctly) waiting to hit its timeout value.  We now give it a shorter timeout value to accelerate the testing process. 