### PR TITLE
Suppress the warning if verify=False

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -183,7 +183,12 @@ class HTTPAdapter(BaseAdapter):
             conn.cert_reqs = 'CERT_REQUIRED'
             conn.ca_certs = cert_loc
         else:
-            conn.cert_reqs = 'CERT_NONE'
+            if verify is False:
+                # Forced by the caller
+                conn.cert_reqs = 'CERT_EXPLICITLY_NONE'
+            else:
+                # Happened to be none
+                conn.cert_reqs = 'CERT_NONE'
             conn.ca_certs = None
 
         if cert:

--- a/requests/packages/urllib3/connection.py
+++ b/requests/packages/urllib3/connection.py
@@ -253,7 +253,8 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             match_hostname(cert, self.assert_hostname or hostname)
 
         self.is_verified = (resolved_cert_reqs == ssl.CERT_REQUIRED
-                            or self.assert_fingerprint is not None)
+                            or self.assert_fingerprint is not None
+                            or self.cert_reqs == 'CERT_EXPLICITLY_NONE')
 
 
 if ssl:

--- a/requests/packages/urllib3/util/ssl_.py
+++ b/requests/packages/urllib3/util/ssl_.py
@@ -129,7 +129,7 @@ def resolve_cert_reqs(candidate):
     If it's neither `None` nor a string we assume it is already the numeric
     constant which can directly be passed to wrap_socket.
     """
-    if candidate is None:
+    if candidate is None or candidate == 'CERT_EXPLICITLY_NONE':
         return CERT_NONE
 
     if isinstance(candidate, str):


### PR DESCRIPTION
Setting verify to False differs from verify=None in being explicitly set,
and therefore the warning being undesirable.

See this for the a proposed alternative that involves importing
implementation details of Requests onto the application:
 https://github.com/kennethreitz/requests/issues/2214#issuecomment-72941896

This fix avoids deep imports and pulling the knowledge of internals of
Requests into the application.

Fixes #2214