### PR TITLE
Raise explicitly when exclusive parameters are provided

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -422,6 +422,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         length = None
 
         if json is not None:
+            if files is not None:
+                raise NotImplementedError('JSON data and files are mutually exclusive.')
             content_type = 'application/json'
             body = json_dumps(json)
 
@@ -456,6 +458,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                         content_type = None
                     else:
                         content_type = 'application/x-www-form-urlencoded'
+                elif data and json is not None:
+                    raise NotImplementedError('JSON data and generic body data are mutually exclusive.')
 
             self.prepare_content_length(body)
 


### PR DESCRIPTION
It's a common case when one sends multipart request with json meta data. Currently, it is not clear that `json` argument is silently omitted. The same happens when both `data` and `json` are provided.