### PR TITLE
document combination of repeated response headers

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -347,6 +347,15 @@ So, we can access the headers using any capitalization we want::
     >>> r.headers.get('content-type')
     'application/json'
 
+It is also special in that the server could have sent the same header multiple
+times with different values, but requests combines them so they can be
+represented in the dictionary within a single mapping, as per
+`RFC 7230 <http://tools.ietf.org/html/rfc7230#section-3.2>`_:
+
+    > A recipient MAY combine multiple header fields with the same field name
+    > into one "field-name: field-value" pair, without changing the semantics
+    > of the message, by appending each subsequent field value to the combined
+    > field value in order, separated by a comma.
 
 Cookies
 -------


### PR DESCRIPTION
as explained in https://github.com/kennethreitz/requests/issues/1155#issuecomment-53229867.

motivation:

requests uses a dict for response headers. In a given response, the same header may appear multiple times with different values, but dicts of course allow each key to map to only one value. requests [handles this intelligently](https://github.com/kennethreitz/requests/issues/1155#issuecomment-53229867), but users will not expect this given it's not documented in any of these places:

- http://docs.python-requests.org/en/latest/user/quickstart/#response-headers
- http://docs.python-requests.org/en/latest/api/?highlight=headers#requests.request
- http://docs.python-requests.org/en/latest/api/#requests.Response.headers

(Also, they may (likely) be unfamiliar with this part of http://tools.ietf.org/html/rfc7230#section-3.2, while only actually being familiar with werkzeug and other libraries that use a multidict instead to handle repeated headers.)

I think there's a perfect spot to document this behavior (right after the docs explain how the dict is already special in that it's case-insensitive), and given that #1155 will probably be closed, I figured it's a good time to document this and increase users' future understanding.

Thanks for the great work on requests.