### PR TITLE
Support for bytearray when creating Request with files argument, just like str and bytes.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -145,7 +145,7 @@ class RequestEncodingMixin(object):
                 fp = v
             if isinstance(fp, str):
                 fp = StringIO(fp)
-            if isinstance(fp, bytes):
+            if isinstance(fp, (bytes, bytearray)):
                 fp = BytesIO(fp)
 
             rf = RequestField(name=k, data=fp.read(),

--- a/test_requests.py
+++ b/test_requests.py
@@ -937,7 +937,7 @@ class RequestsTestCase(unittest.TestCase):
 
     def test_can_send_bytes_bytearray_objects_with_files(self):
         # Test bytes:
-        data = {'a': 0.0}
+        data = {'a': 'this is a string'}
         files = {'b': b'foo'}
         r = requests.Request('POST', httpbin('post'), data=data, files=files)
         p = r.prepare()

--- a/test_requests.py
+++ b/test_requests.py
@@ -935,6 +935,19 @@ class RequestsTestCase(unittest.TestCase):
 
         assert 'multipart/form-data' in p.headers['Content-Type']
 
+    def test_can_send_bytes_bytearray_objects_with_files(self):
+        # Test bytes:
+        data = {'a': 0.0}
+        files = {'b': b'foo'}
+        r = requests.Request('POST', httpbin('post'), data=data, files=files)
+        p = r.prepare()
+        assert 'multipart/form-data' in p.headers['Content-Type']
+        # Test bytearrays:
+        files = {'b': bytearray(b'foo')}
+        r = requests.Request('POST', httpbin('post'), data=data, files=files)
+        p = r.prepare()
+        assert 'multipart/form-data' in p.headers['Content-Type']
+
     def test_can_send_file_object_with_non_string_filename(self):
         f = io.BytesIO()
         f.name = 2


### PR DESCRIPTION
When creating a Request with files argument, the "fp" part of a file entry can currently be either (a) a str, (b) a bytes, or (c) any other object that has a .read() method that returns data. For str or bytes,  StringIO or ByteIO wrapper-objects are created.
When building data in-memory, a bytearray is often more convenient and memory efficient compared to immutable bytes.

This simple change allows models.RequestEncodingMixin._encode_files method to use bytearray as fp in addition to the currently supported bytes and str input. This means that users do not have to worry about creating a ByteIO object. 

I've seen requests users creating bytes-objects from bytearrays before passing it to requests. This, of course, doubles the memory consumption and is completely unnecessary. Yes, the correct approach from the user's side would be to create a ByteIO object (instead of bytes). But not all users seem to be aware of this. Letting requests take bytearrays means that it would "just work", when the user passes these to requests, and thus avoids the potential pitfall where a user just says "requests chokes on bytearrays, so convert to str." (Actual comment from pyzotero, a principal python client module to consume Zotero's REST API).

I'm not sure if this simple change requires it's own test, but I've added one just in case. It also tests for bytes objects, which was not covered by the existing test, test_can_send_nonstring_objects_with_files. Perhaps I should just expand test_can_send_nonstring_objects_with_files to also cover bytes and bytearray? It currently only covers str (which are, of course, also bytes in python 2).

The test suite currently does fail in TestMorselToCookieExpires.test_expires_valid_str; however this is unrelated to this change and was also failing before, in commit 461b740d.

Compatability: bytearray and the byte literal (used in the test) are both available in python 2.6 and forward.

Let me know if there is anything else that you would need in order to accept this pull request.