### PR TITLE
Avoid data duplication when creating a Request with str/bytes/bytearray input

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -143,12 +143,13 @@ class RequestEncodingMixin(object):
             else:
                 fn = guess_filename(v) or k
                 fp = v
-            if isinstance(fp, str):
-                fp = StringIO(fp)
-            if isinstance(fp, (bytes, bytearray)):
-                fp = BytesIO(fp)
 
-            rf = RequestField(name=k, data=fp.read(),
+            if isinstance(fp, (str, bytes, bytearray)):
+                fdata = fp
+            else:
+                fdata = fp.read()
+
+            rf = RequestField(name=k, data=fdata,
                               filename=fn, headers=fh)
             rf.make_multipart(content_type=ft)
             new_fields.append(rf)


### PR DESCRIPTION
I've worked on the idea discussed in #2468 regarding avoiding duplicating the file data when creating a Request with files input that is str/bytes/bytearray and not a stream. The code currently creates a BytesIO or StringIO stream using the str/bytes/bytearray as initial input. This is then read out with fp.read() when creating a RequestField. The problem with this is that BytesIO and StringIO creates a copy of the input. Thus, if you have created a 100 MB file in memory using a bytearray which is used to create a Request, three identical copies is produced:
*(1)* The original bytearray, *(2)* The BytesIO/StringIO object, which has its own copy, and *(3)* The copy that is read out with fp.read() and stored in the RequestField object.

If we instead of creating BytesIO/StringIO objects just pass the str/bytes/bytearray on to RequestField, we avoid making the two duplicates of the data. This yields a **30-40% performance improvement** for files larger than 5 MB when creating a Request. The end result is, as far as I've been able to tell, the same.

I have created a GIST with my code for checking that the proposed change yield the same body as the old. It also has the code for evaluating performance and the results of the three ways I've compared the performance differences. https://gist.github.com/scholer/57fced2b63d1bb3130eb

The tests in test_requests.py completes without failure on python 2.6 and 3.4. I don't believe any new tests are required, but let me know.

**Question:** Is this really relevant? Why would you ever build a large file in memory? Large files are always read from disk or handled as some other stream.
Answer: Some cloud storage services, e.g. Amazon AWS, relies on adding a "prefix" and "suffix" to the file content, which includes e.g. upload authorization tokens. You can build the file data using e.g. a BytesIO stream or a bytearray. The bytearray can be used through a memoryview, which supports Python's buffer protocol. This means that the file data can be inserted directly into the bytearray without extra memory overhead.

    fp.readinto(mv[offset:offset+length])

To my knowledge, it is not easy to read the content of one stream directly into another. For instance, appending a BytesIO with filecontent using  fp.readinto(bytestream) # will fail since bytestream does not support the buffer interface

Note: Although my tests says that the final body is the same with the new code as the old, I would still recommend that someone with more experience takes a look at this to make sure that it does not have any adverse effects.

Thanks.
