### PR TITLE
Sanitise verb string. Now we can use unicode strings in http methods.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -229,7 +229,7 @@ class Request(RequestHooksMixin):
         for (k, v) in list(hooks.items()):
             self.register_hook(event=k, hook=v)
 
-        self.method = method
+        self.method = to_native_string(method)
         self.url = url
         self.headers = headers
         self.files = files

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -681,6 +681,9 @@ def to_native_string(string, encoding='ascii'):
     """
     out = None
 
+    if not string:
+        return string
+
     if isinstance(string, builtin_str):
         out = string
     else:

--- a/test_requests.py
+++ b/test_requests.py
@@ -538,6 +538,18 @@ class RequestsTestCase(unittest.TestCase):
             method=u('POST'), url=httpbin('post'), files=files)
         assert r.status_code == 200
 
+    def test_unicode_method_name_string(self):
+        data = {'stuff': 'ëlïxr'}
+        files = {'file': ('test_requests.py', open(__file__, 'rb'))}
+
+        r = requests.Request(u'POST', httpbin('post'), data=data, files=files)
+        p = r.prepare()
+
+        s = requests.Session()
+        response = s.send(p)
+
+        assert response.status_code == 200
+
     def test_custom_content_type(self):
         r = requests.post(
             httpbin('post'),


### PR DESCRIPTION
There is error (`UnicodeDecodeError: 'ascii' codec can't decode...`) when use unicode string as http verb in instance Request.