### PR TITLE
Don't label cookies for the target domain.

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -171,7 +171,7 @@ class SessionRedirectMixin(object):
             except KeyError:
                 pass
 
-            extract_cookies_to_jar(prepared_request._cookies, prepared_request, resp.raw)
+            extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
             prepared_request._cookies.update(self.cookies)
             prepared_request.prepare_cookies(prepared_request._cookies)
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -171,6 +171,9 @@ class SessionRedirectMixin(object):
             except KeyError:
                 pass
 
+            # Extract any cookies sent on the response to the cookiejar
+            # in the new request. Because we've mutated our copied prepared
+            # request, use the old one that we haven't yet touched.
             extract_cookies_to_jar(prepared_request._cookies, req, resp.raw)
             prepared_request._cookies.update(self.cookies)
             prepared_request.prepare_cookies(prepared_request._cookies)


### PR DESCRIPTION
Per a discussion @sigmavirus24 and I had on the mailing list, this change ensures that we correctly record cookie properties based on the original request, rather than the mutated version.