### PR TITLE
"A CVE identifier"

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,7 @@ Release History
   value set would use the hostname for the redirected URL exposing requests
   users to session fixation attacks and potentially cookie stealing. This was
   disclosed privately by Matthew Daley of `BugFuzz <https://bugfuzz.com>`_.
-  An CVE identifier has not yet been assigned for this. This affects all
+  A CVE identifier has not yet been assigned for this. This affects all
   versions of requests from v2.1.0 to v2.5.3 (inclusive on both ends).
 
 - Fix error when requests is an ``install_requires`` dependency and ``python


### PR DESCRIPTION
I believe this is the more correct grammar?