### PR TITLE
Expand on chunked handling.

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -278,7 +278,8 @@ For chunked encoded responses, it's best to iterate over the data using
 :meth:`Response.iter_content() <requests.models.Response.iter_content>`. In
 an ideal situation you'll have set ``stream=True`` on the request, in which
 case you can iterate chunk-by-chunk by calling ``iter_content`` with a chunk
-size parameter of ``None``.
+size parameter of ``None``. If you want to set a maximum size of the chunk,
+you can set a chunk size parameter to any integer.
 
 
 .. _multipart:

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -268,12 +268,17 @@ Requests also supports Chunked transfer encoding for outgoing and incoming reque
 To send a chunk-encoded request, simply provide a generator (or any iterator without
 a length) for your body::
 
-
     def gen():
         yield 'hi'
         yield 'there'
 
     requests.post('http://some.url/chunked', data=gen())
+
+For chunked encoded responses, it's best to iterate over the data using
+:meth:`Response.iter_content() <requests.models.Response.iter_content>`. In
+an ideal situation you'll have set ``stream=True`` on the request, in which
+case you can iterate chunk-by-chunk by calling ``iter_content`` with a chunk
+size parameter of ``None``.
 
 
 .. _multipart:


### PR DESCRIPTION
Once we merge in the new urllib3, this will update the docs to reflect the new best way to handle chunked transfer encoding.