### PR TITLE
Minor Patch TypeError thrown

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -161,3 +161,4 @@ Patches and Suggestions
 - Arthur Darcet (`@arthurdarcet <https://github.com/arthurdarcet>`_)
 - Ulrich Petri (`@ulope <https://github.com/ulope>`_)
 - Muhammad Yasoob Ullah Khalid <yasoob.khld@gmail.com> (`@yasoob <https://github.com/yasoob>`_)
+- Josh Brown (`@Montycarlo <https://github.com/Montycarlo>`_)

--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -311,8 +311,14 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         # Catch possible read timeouts thrown as SSL errors. If not the
         # case, rethrow the original. We need to do this because of:
         # http://bugs.python.org/issue10272
-        if 'timed out' in str(err) or 'did not complete (read)' in str(err):  # Python 2.6
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+        # Wrapped in a try/catch because python 2.7 throws TypeError,
+        # SSLError doesn't override __str__
+        try:
+            if 'timed out' in str(err) or 'did not complete (read)' in str(err):  # Python 2.6
+                raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+        except TypeError:
+            raise err
+
 
     def _make_request(self, conn, method, url, timeout=_Default,
                       **httplib_request_kw):


### PR DESCRIPTION
Python2.7, str(err) was throwing a TypeError as it doesn't override the 'toString' method __str__.

Wrapped offending block in a quick try block, catching only TypeError exceptions.