### PR TITLE
Import the builtin json first.

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -22,11 +22,9 @@ is_py2 = (_ver[0] == 2)
 is_py3 = (_ver[0] == 3)
 
 try:
-    import simplejson as json
-except (ImportError, SyntaxError):
-    # simplejson does not support Python 3.2, it throws a SyntaxError
-    # because of u'...' Unicode literals.
     import json
+except ImportError:
+    import simplejson as json
 
 # ---------
 # Specifics


### PR DESCRIPTION
`simplejson` segfaults for me ([details](https://github.com/simplejson/simplejson/issues/114)) and it looks like it's not maintained. It should only be used as a last resort.