### PR TITLE
Place VendorAlias first in meta_path

### DIFF
--- a/requests/packages/__init__.py
+++ b/requests/packages/__init__.py
@@ -104,4 +104,4 @@ class VendorAlias(object):
         return module
 
 
-sys.meta_path.append(VendorAlias(["urllib3", "chardet"]))
+sys.meta_path.insert(0, VendorAlias(["urllib3", "chardet"]))


### PR DESCRIPTION
When other libraries or tools add items to the meta_path, we need to preempt
some of their import hooks to be sure modules can be properly found. This also
prevents problems importing built-in modules on Python 2 where it will first
attempt to import something like:

    requests.packages.chardet.sys

By placing our VendorAlias first, the above will fail and then it will fall
back to trying to import sys directly instead.

Closes #2465