### PR TITLE
Document that "PreparedRequest.prepare_cookies" can only be called once

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -501,7 +501,15 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             self.prepare_content_length(self.body)
 
     def prepare_cookies(self, cookies):
-        """Prepares the given HTTP cookie data."""
+        """Prepares the given HTTP cookie data.
+
+        This function eventually generates a ``Cookie`` header from the
+        given cookies using cookielib. Due to cookielib's design, the header
+        will not be regenerated if it already exists, meaning this function
+        can only be called once for the life of the
+        :class:`PreparedRequest <PreparedRequest>` object. Any subsequent calls
+        to ``prepare_cookies`` will have no actual effect, unless the "Cookie"
+        header is removed beforehand."""
 
         if isinstance(cookies, cookielib.CookieJar):
             self._cookies = cookies


### PR DESCRIPTION
I've done the documentation changes suggested in #2532.

I also documented a way to work around this in the docstring, but I'm not sure if it'd be good to do so. (As it may lead to hacked-together solutions) Then again, other solutions like creating a brand new `Request` might lead to worse problems. (e.g.: loss of data)

@sigmavirus24, what do you think?