### PR TITLE
Add a timeout to select(), otherwise we can block forever on a bad socket

### DIFF
--- a/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/requests/packages/urllib3/contrib/pyopenssl.py
@@ -299,7 +299,9 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         try:
             cnx.do_handshake()
         except OpenSSL.SSL.WantReadError:
-            select.select([sock], [], [])
+            rd, _, _ = select.select([sock], [], [], sock.gettimeout())
+            if not rd:
+                raise timeout('The read operation timed out')
             continue
         except OpenSSL.SSL.Error as e:
             raise ssl.SSLError('bad handshake', e)


### PR DESCRIPTION
All the other select.select() calls in this module use a timeout. Without this bugfix, a server that fails to complete the handshake will block forever. We've seen this in production.