### PR TITLE
Make docstring of api.get more clear

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -55,17 +55,18 @@ def request(method, url, **kwargs):
     return response
 
 
-def get(url, **kwargs):
+def get(url, params=None, **kwargs):
     """Sends a GET request.
 
     :param url: URL for the new :class:`Request` object.
+    :param params: (optional) Dictionary or bytes to be sent in the query string for the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
     """
 
     kwargs.setdefault('allow_redirects', True)
-    return request('get', url, **kwargs)
+    return request('get', url, params=params, **kwargs)
 
 
 def options(url, **kwargs):


### PR DESCRIPTION
I opened issue #2581, and since it is such a small change, I just went ahead and opened the pull request immediately.

This makes the docstring for `requests.get` clearer so when someone does `help(requests.get)` they can see that `params` is an optional kwarg that can be used to attach query string parameters to a GET request.  I think this change makes it symmetric with `requests.post` which specifically mentions `data` and `json` for body and json parameters.  As I mentioned in #2581, query string parameters are as relevant to GET requests as json and body parameters are to POST requests, so this change makes a lot of sense in that respect. 