### PR TITLE
Remove the __bool__ and __nonzero__ response methods

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,0 +1,11 @@
+3.0.0 (2015-xx-xx)
+++++++++++++++++++
+
+- Remove the ``__bool__`` and ``__nonzero__`` methods from a ``Response``
+  object.
+
+  This has been a planned feature for over a year. The behaviour is surprising
+  to most people and breaks most of the assumptions that people have about
+  Response objects. This resolves issue `#2002`_
+
+.. _#2002: https://github.com/kennethreitz/requests/issues/2002

--- a/requests/models.py
+++ b/requests/models.py
@@ -619,14 +619,6 @@ class Response(object):
     def __repr__(self):
         return '<Response [%s]>' % (self.status_code)
 
-    def __bool__(self):
-        """Returns true if :attr:`status_code` is 'OK'."""
-        return self.ok
-
-    def __nonzero__(self):
-        """Returns true if :attr:`status_code` is 'OK'."""
-        return self.ok
-
     def __iter__(self):
         """Allows you to use a response as an iterator."""
         return self.iter_content(128)


### PR DESCRIPTION
Many people expect to be able to say:

    response = make_request(url)

    if response:
        body = response.content

Where the first part should test for whether or not response is None.
Instead, the __bool__ and __nonzero__ methods return response.ok, so if
the response is actually a 4xx or 5xx response, then the user would
expect to get the body of the response.

By removing these methods, we restore the functionality that most users
expect.

Closes #2002 

----

**Note** this is development for 3.0.0