### PR TITLE
morsel['max-age'] may be a str. Should it be converted to float?

### DIFF
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -418,7 +418,7 @@ def morsel_to_cookie(morsel):
         try:
             expires = time.time() + float(morsel['max-age'])
         except ValueError:
-            pass
+            raise TypeError('max-age: %s must be integer' % morsel['max-age'])
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
         expires = time.mktime(

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -415,7 +415,7 @@ def morsel_to_cookie(morsel):
 
     expires = None
     if morsel['max-age']:
-        expires = time.time() + morsel['max-age']
+        expires = time.time() + float(morsel['max-age'])
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
         expires = time.mktime(

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -416,13 +416,13 @@ def morsel_to_cookie(morsel):
     expires = None
     if morsel['max-age']:
         try:
-            expires = time.time() + int(morsel['max-age'])
+            expires = int(time.time() + int(morsel['max-age']))
         except ValueError:
             raise TypeError('max-age: %s must be integer' % morsel['max-age'])
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
-        expires = time.mktime(
-            time.strptime(morsel['expires'], time_template)) - time.timezone
+        expires = int(time.mktime(
+            time.strptime(morsel['expires'], time_template)) - time.timezone)
     return create_cookie(
         comment=morsel['comment'],
         comment_url=bool(morsel['comment']),

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -415,7 +415,10 @@ def morsel_to_cookie(morsel):
 
     expires = None
     if morsel['max-age']:
-        expires = time.time() + float(morsel['max-age'])
+        try:
+            expires = time.time() + float(morsel['max-age'])
+        except ValueError:
+            pass
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
         expires = time.mktime(

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -416,7 +416,7 @@ def morsel_to_cookie(morsel):
     expires = None
     if morsel['max-age']:
         try:
-            expires = time.time() + float(morsel['max-age'])
+            expires = time.time() + int(morsel['max-age'])
         except ValueError:
             raise TypeError('max-age: %s must be integer' % morsel['max-age'])
     elif morsel['expires']:


### PR DESCRIPTION
Example:

here are Set-Cookie list:
```python
sclst = ['dwac_bcIBMiaagZmkYaaadeYtg11eVR=j9jHdmPjUhgDOhyH9f89X4lQgehEmflVyeA%3D|dw-only|||CNY|false|Asia%2FShanghai|true; Path=/',
 'sid=j9jHdmPjUhgDOhyH9f89X4lQgehEmflVyeA; Path=/',
 'geoLocation=CN; Path=/',
 'dwpersonalization_fae107a9dd0fc32ed99532ec1977f31f=bc8sEiaagZqRsaaadk8XoNTL8h20150506; Expires=Sun, 14-Jun-2015 10:37:07 GMT; Path=/',
 'dwanonymous_fae107a9dd0fc32ed99532ec1977f31f=abjpA8kng31LjPp8ZEERDT4XVg; Version=1; Comment="Demandware anonymous cookie for site Sites-abercrombie_cn-Site"; Max-Age=15552000; Expires=Tue, 10-Nov-2015 10:37:07 GMT; Path=/',
 'myStore=91156; Path=/',
 'AF_PREF=en_CN; Path=/',
 'dwsid=MiHJy3KYZKDcN0lZg4HS1zSpj1VV4s_tFu39ar0KXNpAx9aX8X2LlvZQ9m5fOOknb6QXtmmukHcOjmivYf31hg==; path=/; HttpOnly']
```

```python
    for sc in sclst:
        C = Cookie.SimpleCookie(sc)
        for morsel in C.values():
            cookie = requests.cookies.morsel_to_cookie(morsel)
            cookiejar.set_cookie(cookie)
```
Then, exception occured
```shell
  File "/Library/Python/2.7/site-packages/requests/cookies.py", line 402, in morsel_to_cookie
    expires = time.time() + morsel['max-age']
TypeError: unsupported operand type(s) for +: 'float' and 'str'
```

As Cookie.SimpleCookie is in STL, should `morsel_to_cookie` check the type of `max-age`? On the other hand, if **max-age** can not be converted to float, it's illegal obviously.