### PR TITLE
Change "Staring new HTTP/S connection..." log message to DEBUG level

### DIFF
--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -199,7 +199,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTP connection (%d): %s" %
+        log.debug("Starting new HTTP connection (%d): %s" %
                  (self.num_connections, self.host))
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
@@ -731,7 +731,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTPS connection (%d): %s"
+        log.debug("Starting new HTTPS connection (%d): %s"
                  % (self.num_connections, self.host))
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:


### PR DESCRIPTION
Of course there are ways to work around this on a per-execution basis (programmatically or manually), but I figured I'd address what I've heard from various developers as "the only annoying thing about python requests".