### PR TITLE
Don’t break IPv6 address format

### DIFF
--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -64,8 +64,7 @@ class ConnectionPool(object):
         if not host:
             raise LocationValueError("No host specified.")
 
-        # httplib doesn't like it when we include brackets in ipv6 addresses
-        self.host = host.strip('[]')
+        self.host = host
         self.port = port
 
     def __str__(self):


### PR DESCRIPTION
No idea what this does to older supported Python versions. In Python 3.4.2, at least, you can’t strip away the brackets otherwise no IPv6 address will resolve.