### PR TITLE
Move native string conversion to Request

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -230,7 +230,7 @@ class Request(RequestHooksMixin):
         for (k, v) in list(hooks.items()):
             self.register_hook(event=k, hook=v)
 
-        self.method = to_native_string(method)
+        self.method = method
         self.url = url
         self.headers = headers
         self.files = files
@@ -328,8 +328,9 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
     def prepare_method(self, method):
         """Prepares the given HTTP method."""
         self.method = method
-        if self.method is not None:
-            self.method = self.method.upper()
+        if self.method is None:
+            raise ValueError('Request method cannot be "None"')
+        self.method = to_native_string(self.method).upper()
 
     def prepare_url(self, url, params):
         """Prepares the given HTTP URL."""

--- a/requests/models.py
+++ b/requests/models.py
@@ -226,6 +226,9 @@ class Request(RequestHooksMixin):
         params = {} if params is None else params
         hooks = {} if hooks is None else hooks
 
+        # Default empty string for method.
+        method = '' if method is None else method
+
         self.hooks = default_hooks()
         for (k, v) in list(hooks.items()):
             self.register_hook(event=k, hook=v)

--- a/requests/models.py
+++ b/requests/models.py
@@ -226,9 +226,6 @@ class Request(RequestHooksMixin):
         params = {} if params is None else params
         hooks = {} if hooks is None else hooks
 
-        # Default empty string for method.
-        method = '' if method is None else method
-
         self.hooks = default_hooks()
         for (k, v) in list(hooks.items()):
             self.register_hook(event=k, hook=v)

--- a/requests/models.py
+++ b/requests/models.py
@@ -230,7 +230,7 @@ class Request(RequestHooksMixin):
         for (k, v) in list(hooks.items()):
             self.register_hook(event=k, hook=v)
 
-        self.method = method
+        self.method = to_native_string(method)
         self.url = url
         self.headers = headers
         self.files = files

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -432,9 +432,6 @@ class Session(SessionRedirectMixin):
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         """
-
-        method = to_native_string(method)
-
         # Create the Request.
         req = Request(
             method = method.upper(),

--- a/test_requests.py
+++ b/test_requests.py
@@ -89,7 +89,7 @@ class RequestsTestCase(unittest.TestCase):
             requests.get('http://')
 
     def test_basic_building(self):
-        req = requests.Request()
+        req = requests.Request(method='GET')
         req.url = 'http://kennethreitz.org/'
         req.data = {'life': '42'}
 
@@ -813,7 +813,7 @@ class RequestsTestCase(unittest.TestCase):
         assert ('user', 'pass#pass') == requests.utils.get_auth_from_url(url)
 
     def test_cannot_send_unprepared_requests(self):
-        r = requests.Request(url=HTTPBIN)
+        r = requests.Request(method='GET', url=HTTPBIN)
         with pytest.raises(ValueError):
             requests.Session().send(r)
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -1618,7 +1618,7 @@ def test_prepare_unicode_url():
 
 
 def test_prepare_requires_a_request_method():
-    req = Request()
+    req = requests.Request()
     with pytest.raises(ValueError):
         req.prepare()
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -1617,6 +1617,16 @@ def test_prepare_unicode_url():
     assert_copy(p, p.copy())
 
 
+def test_prepare_requires_a_request_method():
+    req = Request()
+    with pytest.raises(ValueError):
+        req.prepare()
+
+    prepped = PreparedRequest()
+    with pytest.raises(ValueError):
+        prepped.prepare()
+
+
 def test_urllib3_retries():
     from requests.packages.urllib3.util import Retry
     s = requests.Session()


### PR DESCRIPTION
This fixes #2613. I believe that this technically constitutes a backward-incompatible API change, so I've proposed this against 3.0.0. Let me know if you disagree @sigmavirus24 (the other option is really that this is a bugfix), and I'll propose against master.