### PR TITLE
Declare tests_require and hook up 'test' command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ packages = [
 ]
 
 requires = []
+tests_require = ['pytest']
 
 version = ''
 with open('requests/__init__.py', 'r') as fd:
@@ -54,6 +55,8 @@ setup(
     package_dir={'requests': 'requests'},
     include_package_data=True,
     install_requires=requires,
+    tests_require=tests_require,
+    test_suite='test_requests',
     license='Apache 2.0',
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
This change allows the existing test script (test_requests.py) to be invoked via the standard setuptools test command. It also declares pytest as a test_dependency, so that it is installed on a test run, if not available.