### PR TITLE
Handle empty chunks

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -388,7 +388,10 @@ class HTTPAdapter(BaseAdapter):
                     low_conn.endheaders()
 
                     for i in request.body:
-                        low_conn.send(hex(len(i))[2:].encode('utf-8'))
+                        chunk_size = len(i)
+                        if chunk_size == 0:
+                            continue
+                        low_conn.send(hex(chunk_size)[2:].encode('utf-8'))
                         low_conn.send(b'\r\n')
                         low_conn.send(i)
                         low_conn.send(b'\r\n')


### PR DESCRIPTION
Empty chunk in request body could prematurely signal end of chunked
transmission. As a result, the terminating zero-size chunk sent by
'requests' can be interpretted as bad request by the recepient. I
have used the same logic used by httplib to handle such cases.