### PR TITLE
Display URL as part of HTTP error messages

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -828,10 +828,10 @@ class Response(object):
         http_error_msg = ''
 
         if 400 <= self.status_code < 500:
-            http_error_msg = '%s Client Error: %s' % (self.status_code, self.reason)
+            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, self.reason, self.url)
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = '%s Server Error: %s' % (self.status_code, self.reason)
+            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, self.reason, self.url)
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)


### PR DESCRIPTION
It seems convenient to include the URL in the error message in case you get an unexpected error.

E.g.:

    In [1]: import requests

    In [2]: resp = requests.get('http://www.google.com/eofdfdfdfdfd')

    In [3]: resp
    Out[3]: <Response [404]>

    In [4]: resp.raise_for_status()
    ---------------------------------------------------------------------------
    HTTPError                                 Traceback (most recent call last)
    <ipython-input-4-00e7077cfb5b> in <module>()
    ----> 1 resp.raise_for_status()

    /Users/marca/dev/git-repos/requests/requests/models.py in raise_for_status(self)
        835
        836         if http_error_msg:
    --> 837             raise HTTPError(http_error_msg, response=self)
        838
        839     def close(self):

    HTTPError: 404 Client Error: Not Found for url: http://www.google.com/eofdfdfdfdfd