### PR TITLE
Handle complex redirect URIs on Python 3

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -13,7 +13,7 @@ from collections import Mapping
 from datetime import datetime
 
 from .auth import _basic_auth_str
-from .compat import cookielib, OrderedDict, urljoin, urlparse
+from .compat import cookielib, OrderedDict, urljoin, urlparse, is_py3, str
 from .cookies import (
     cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar, merge_cookies)
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
@@ -127,6 +127,13 @@ class SessionRedirectMixin(object):
             # The scheme should be lower case...
             parsed = urlparse(url)
             url = parsed.geturl()
+
+            # On Python 3, the location header was decoded using Latin 1, but
+            # urlparse in requote_uri will encode it with UTF-8 before quoting.
+            # Because of this insanity, we need to fix it up ourselves by
+            # sending the URL back to bytes ourselves.
+            if is_py3 and isinstance(url, str):
+                url = url.encode('latin1')
 
             # Facilitate relative 'location' headers, as allowed by RFC 7231.
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -396,7 +396,7 @@ def unquote_unreserved(uri):
     """Un-escape any percent-escape sequences in a URI that are unreserved
     characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
     """
-    parts = uri.split('%')
+    parts = uri.split(b'%')
     for i in range(1, len(parts)):
         h = parts[i][0:2]
         if len(h) == 2 and h.isalnum():

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -396,7 +396,15 @@ def unquote_unreserved(uri):
     """Un-escape any percent-escape sequences in a URI that are unreserved
     characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
     """
-    parts = uri.split(b'%')
+    # Handle both bytestrings and unicode strings.
+    if isinstance(uri, bytes):
+        splitchar = b'%'
+        base = b''
+    else:
+        splitchar = u'%'
+        base = u''
+
+    parts = uri.split(splitchar)
     for i in range(1, len(parts)):
         h = parts[i][0:2]
         if len(h) == 2 and h.isalnum():
@@ -408,10 +416,10 @@ def unquote_unreserved(uri):
             if c in UNRESERVED_SET:
                 parts[i] = c + parts[i][2:]
             else:
-                parts[i] = '%' + parts[i]
+                parts[i] = splitchar + parts[i]
         else:
-            parts[i] = '%' + parts[i]
-    return ''.join(parts)
+            parts[i] = splitchar + parts[i]
+    return base.join(parts)
 
 
 def requote_uri(uri):


### PR DESCRIPTION
Resolves #2653.

This is one of those annoying changes that's almost impossible to test because of the sheer complexity of our redirect handling code. This also doesn't make it any simpler, sadly.

As to what version we merge this into, I proposed it against the master branch. I don't think it belongs in 3.0.0 (`resolve_redirects` isn't really part of our public API), but it could definitely break people's stuff. Next minor release feels appropriate, but I'd like to hear what you think @sigmavirus24.