### PR TITLE
Allow get_netrc_auth to raise parse/permission errors to caller

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -67,7 +67,7 @@ def super_len(o):
         return len(o.getvalue())
 
 
-def get_netrc_auth(url):
+def get_netrc_auth(url, ignore_errors=True):
     """Returns the Requests tuple auth for a given url from netrc."""
 
     try:
@@ -106,7 +106,8 @@ def get_netrc_auth(url):
         except (NetrcParseError, IOError):
             # If there was a parsing error or a permissions issue reading the file,
             # we'll just skip netrc auth
-            pass
+            if not ignore_errors:
+                raise
 
     # AppEngine hackiness.
     except (ImportError, AttributeError):

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -67,7 +67,7 @@ def super_len(o):
         return len(o.getvalue())
 
 
-def get_netrc_auth(url, ignore_errors=True):
+def get_netrc_auth(url, raise_errors=False):
     """Returns the Requests tuple auth for a given url from netrc."""
 
     try:
@@ -105,8 +105,8 @@ def get_netrc_auth(url, ignore_errors=True):
                 return (_netrc[login_i], _netrc[2])
         except (NetrcParseError, IOError):
             # If there was a parsing error or a permissions issue reading the file,
-            # we'll just skip netrc auth
-            if not ignore_errors:
+            # we'll just skip netrc auth unless explicitly asked to raise errors.
+            if raise_errors:
                 raise
 
     # AppEngine hackiness.


### PR DESCRIPTION
If the netrc file exists but cannot be parsed or read, get_netrc_auth
silently fails.

Add a new argument `ignore_errors` which when set to False will cause
any parse/permission errors to be raised to the caller.  The default
value is True, which means the default behavior is unchanged.

Fixes #2654

Change-Id: I7436aaaf593178673ab84fd9e7ab4bcb0e3fe75e