### PR TITLE
Only pass useful timeouts to _get_conn

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -35,6 +35,7 @@ from .auth import _basic_auth_str
 DEFAULT_POOLBLOCK = False
 DEFAULT_POOLSIZE = 10
 DEFAULT_RETRIES = 0
+DEFAULT_POOL_TIMEOUT = None
 
 
 class BaseAdapter(object):
@@ -375,7 +376,7 @@ class HTTPAdapter(BaseAdapter):
                 if hasattr(conn, 'proxy_pool'):
                     conn = conn.proxy_pool
 
-                low_conn = conn._get_conn(timeout=timeout)
+                low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
 
                 try:
                     low_conn.putrequest(request.method,


### PR DESCRIPTION
So `_get_conn` doesn't use a urllib3 `Timeout` object, it only takes a float. It also only does stuff if `block` is `True`. Given that by default we use `block=False`, it won't do anything, so let's not use it. However, if someone changes that with a global constant they may want to be able to change this too, so let's make it a named constant.