### PR TITLE
Allow non-latin1 credentials

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -27,7 +27,7 @@ def _basic_auth_str(username, password):
     """Returns a Basic Auth string."""
 
     authstr = 'Basic ' + to_native_string(
-        b64encode(('%s:%s' % (username, password)).encode('latin1')).strip()
+        b64encode(('%s:%s' % (username, password))).encode('latin1').strip()
     )
 
     return authstr


### PR DESCRIPTION
Referring to #1926
Maybe I am wrong, but my understanding was that header fields must be latin-1 encoded.
This is awlays true for Basic Authentication headers, since base64 encoded strings consist of plain ascii.  
I would think however that `<username>:<password>` may contain special characters, as long as client and server assume the same encoding (for example utf8).

This code currently encodes the credentials:
```py
def _basic_auth_str(username, password):
    """Returns a Basic Auth string."""

    authstr = 'Basic ' + to_native_string(
        b64encode(('%s:%s' % (username, password)).encode('latin1')).strip()
    )

    return authstr
```

but could be changed to encode the base64 header string instead:
```py
        ...
        b64encode(('%s:%s' % (username, password))).encode('latin1').strip()
```