### PR TITLE
Test CaseInsensitiveDict.__repr__ unordered

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -1277,7 +1277,7 @@ class TestCaseInsensitiveDict(unittest.TestCase):
             'Accept': 'application/json',
             'user-Agent': 'requests',
         })
-        assert repr(cid) == "{'Accept': 'application/json', 'user-Agent': 'requests'}"
+        assert set(repr(cid).strip('{}').split(', ')) == set(["'Accept': 'application/json'", "'user-Agent': 'requests'"])
 
 
 class UtilsTestCase(unittest.TestCase):


### PR DESCRIPTION
InsensitiveDict.__repr__ does not order the members, which on
Python 3 causes TestCaseInsensitiveDict.test_repr to fail.

Fixes issue #2668