### PR TITLE
Fix quickstart "Custom Headers" example intro

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -182,7 +182,7 @@ Custom Headers
 If you'd like to add HTTP headers to a request, simply pass in a ``dict`` to the
 ``headers`` parameter.
 
-For example, we didn't specify our content-type in the previous example::
+For example, we didn't specify our user-agent in the previous example::
 
     >>> import json
     >>> url = 'https://api.github.com/some/endpoint'


### PR DESCRIPTION
Previously this section prefaced an example with:

    For example, we didn't specify our content-type

But, the actual example set a custom user-agent header on the request. This
changes it to say "user-agent" instead which matches the given example.