### PR TITLE
Fix docs for passing a list of values for a query string

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -73,13 +73,12 @@ You can see that the URL has been correctly encoded by printing the URL::
 Note that any dictionary key whose value is ``None`` will not be added to the
 URL's query string.
 
-In order to pass a list of items as a value you must mark the key as
-referring to a list like string by appending ``[]`` to the key::
+You can also pass a list of items as a value::
 
-    >>> payload = {'key1': 'value1', 'key2[]': ['value2', 'value3']}
+    >>> payload = {'key1': 'value1', 'key2': ['value2', 'value3']}
     >>> r = requests.get("http://httpbin.org/get", params=payload)
     >>> print(r.url)
-    http://httpbin.org/get?key1=value1&key2%5B%5D=value2&key2%5B%5D=value3
+    http://httpbin.org/get?key1=value1&key2=value2&key2=value3
 
 Response Content
 ----------------


### PR DESCRIPTION
The special `[]` notation at the end of the field name is not necessary to get a field to appear with multiple values in the query string.