### PR TITLE
Fix merge setting for not preserving original order of dict parameters

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -63,11 +63,9 @@ def merge_setting(request_setting, session_setting, dict_class=OrderedDict):
     merged_setting.update(to_key_val_list(request_setting))
 
     # Remove keys that are set to None.
-    for (k, v) in request_setting.items():
+    for (k, v) in merged_setting.items():
         if v is None:
             del merged_setting[k]
-
-    merged_setting = dict((k, v) for (k, v) in merged_setting.items() if v is not None)
 
     return merged_setting
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -125,6 +125,13 @@ class RequestsTestCase(unittest.TestCase):
             "http://example.com/path?key=value#fragment", params={"a": "b"}).prepare()
         assert request.url == "http://example.com/path?key=value&a=b#fragment"
 
+    def test_params_original_order_is_preserved_by_default(self):
+        param_ordered_dict = collections.OrderedDict((('z', 1), ('a', 1), ('k', 1), ('d', 1)))
+        session = requests.Session()
+        request = requests.Request('GET', 'http://example.com/', params=param_ordered_dict)
+        prep = session.prepare_request(request)
+        assert prep.url == 'http://example.com/?z=1&a=1&k=1&d=1'
+
     def test_mixed_case_scheme_acceptable(self):
         s = requests.Session()
         s.proxies = getproxies()


### PR DESCRIPTION
Fix a bug introduced by https://github.com/kennethreitz/requests/pull/1921

Bug: the ordered dictionary (the default `dict_class`) is accidentally converted back to normal dictionary.