### PR TITLE
Document use of sessions as context managers

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -12,7 +12,10 @@ Session Objects
 
 The Session object allows you to persist certain parameters across
 requests. It also persists cookies across all requests made from the
-Session instance.
+Session instance, and will use ``urllib3``'s `connection pooling`_. So if
+you're making several requests to the same host, the underlying TCP
+connection will be reused, which can result in a significant performance
+increase (see `HTTP persistent connection`_).
 
 A Session object has all the methods of the main Requests API.
 
@@ -836,5 +839,7 @@ system.
 
 For the sake of security we recommend upgrading certifi frequently!
 
+.. _HTTP persistent connection: https://en.wikipedia.org/wiki/HTTP_persistent_connection
+.. _connection pooling: https://urllib3.readthedocs.org/en/latest/pools.html
 .. _certifi: http://certifi.io/
 .. _Mozilla trust store: https://hg.mozilla.org/mozilla-central/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -42,6 +42,15 @@ Any dictionaries that you pass to a request method will be merged with the
 session-level values that are set. The method-level parameters override session
 parameters.
 
+Sessions can also be used as context managers::
+
+    with requests.Session() as s:
+        s.get('http://httpbin.org/cookies/set/sessioncookie/123456789')
+
+This will make sure the session is closed as soon as the ``with`` block is
+exited, even if unhandled exceptions occured.
+
+
 .. admonition:: Remove a Value From a Dict Parameter
 
     Sometimes you'll want to omit session-level keys from a dict parameter. To

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -275,6 +275,12 @@ class Session(SessionRedirectMixin):
       >>> s = requests.Session()
       >>> s.get('http://httpbin.org/get')
       200
+
+    Or as a context manager::
+
+      >>> with requests.Session() as s:
+      >>>     s.get('http://httpbin.org/get')
+      200
     """
 
     __attrs__ = [


### PR DESCRIPTION
This adds some documentation on how to use sessions as **context managers** (fixes #2580). I also added a brief mention of **connection pooling** and its performance benefits.

I still got one question though: Is instantiating [`Session`](https://github.com/kennethreitz/requests/blob/9b067db19e20226dcb3aa407605d30942d085050/requests/sessions.py#L267) directly the proper API to document? I noticed that there's also a [`session()` factory function](https://github.com/kennethreitz/requests/blob/9b067db19e20226dcb3aa407605d30942d085050/requests/sessions.py#L674-L677) that explicitly mentions context management in its docstring. But I then saw this in the [API changes section](http://www.python-requests.org/en/latest/api/?highlight=backwards%20compatibility#api-changes):

> The `Session` API has changed. Sessions objects no longer take parameters. `Session` is also now capitalized, but it can still be instantiated with a lowercase `session` for backwards compatibility.

So I therefore used `Session()` in the examples, and I'm assuming that factory function is only there for backwards compatibility. Should I update its docstring with something like `Alias for backwards compatibility`?

Let me know how you'd like it documented, and I'll update my PR accordingly.