### PR TITLE
Docs: Clarify that method-level parameters are not persisted in sessions.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -81,6 +81,8 @@ Status Code Lookup
     >>> requests.codes['\o/']
     200
 
+.. _api-cookies:
+
 Cookies
 ~~~~~~~
 

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -45,6 +45,24 @@ Any dictionaries that you pass to a request method will be merged with the
 session-level values that are set. The method-level parameters override session
 parameters.
 
+Note, however, that method-level parameters will *not* be persisted across
+requests, even if using a session. This example will only send the cookies
+with the first request, but not the second::
+
+    s = requests.Session()
+    r = s.get('http://httpbin.org/cookies', cookies={'from-my': 'browser'})
+    print(r.text)
+    # '{"cookies": {"from-my": "browser"}}'
+
+    r = s.get('http://httpbin.org/cookies')
+    print(r.text)
+    # '{"cookies": {}}'
+
+
+If you want to manually add cookies to your session, use the
+:ref:`Cookie utility functions <api-cookies>` to manipulate
+:attr:`Session.cookies <requests.Session.cookies>`.
+
 Sessions can also be used as context managers::
 
     with requests.Session() as s:


### PR DESCRIPTION
This adds a paragraph to the **session docs** that clarifies the fact that **method-level parameters are not persisted across requests**, even when a session is being used (fixes #2488).

As an example I used cookies, and included a pointer to the [Cookie utility functions](http://docs.python-requests.org/en/latest/api/#cookies). In order to be able to link to that section I added some section labels in `docs/api.rst` (prefixed with `api-`, because otherwise there would be label collisions).