### PR TITLE
[WIP] Add a custom requests cookie policy

### DIFF
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -157,6 +157,17 @@ class CookieConflictError(RuntimeError):
     Use .get and .set and include domain and path args in order to be more specific."""
 
 
+def requests_cookie_policy(**kwargs):
+    """Create a cookie policy with a strict domain policy.
+
+    This accepts all of the same kwargs as
+    :class:`cookielib.DefaultCookiePolicy`.
+    """
+    kwargs.setdefault('strict_ns_domain',
+                      cookielib.DefaultCookiePolicy.DomainStrict)
+    return cookielib.DefaultCookiePolicy(**kwargs)
+
+
 class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
     """Compatibility class; is a cookielib.CookieJar, but exposes a dict
     interface.
@@ -174,6 +185,12 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
 
     .. warning:: dictionary operations that are normally O(1) may be O(n).
     """
+    def __init__(self, policy=None):
+        if policy is None:
+            policy = requests_cookie_policy()
+
+        super(RequestsCookieJar, self).__init__(policy)
+
     def get(self, name, default=None, domain=None, path=None):
         """Dict-like get() that also supports optional domain and path args in
         order to resolve naming collisions from using one cookie jar over

--- a/requests/models.py
+++ b/requests/models.py
@@ -15,7 +15,7 @@ from .hooks import default_hooks
 from .structures import CaseInsensitiveDict
 
 from .auth import HTTPBasicAuth
-from .cookies import cookiejar_from_dict, get_cookie_header, _copy_cookie_jar
+from .cookies import cookiejar_from_dict, get_cookie_header, _copy_cookie_jar, RequestsCookieJar
 from .packages.urllib3.fields import RequestField
 from .packages.urllib3.filepost import encode_multipart_formdata
 from .packages.urllib3.util import parse_url
@@ -584,7 +584,7 @@ class Response(object):
         self.reason = None
 
         #: A CookieJar of Cookies the server sent back.
-        self.cookies = cookiejar_from_dict({})
+        self.cookies = RequestsCookieJar()
 
         #: The amount of time elapsed between sending the request
         #: and the arrival of the response (as a timedelta).

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -327,7 +327,7 @@ class Session(SessionRedirectMixin):
         #: session. By default it is a
         #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`, but
         #: may be any other ``cookielib.CookieJar`` compatible object.
-        self.cookies = cookiejar_from_dict({})
+        self.cookies = RequestsCookieJar()
 
         # Default connection adapters.
         self.adapters = OrderedDict()
@@ -353,10 +353,11 @@ class Session(SessionRedirectMixin):
             session's settings.
         """
         cookies = request.cookies or {}
+        host = urlparse(request.url).netloc
 
         # Bootstrap CookieJar.
         if not isinstance(cookies, cookielib.CookieJar):
-            cookies = cookiejar_from_dict(cookies)
+            cookies = cookiejar_from_dict(cookies, host)
 
         # Merge with session cookies
         merged_cookies = merge_cookies(

--- a/test_requests.py
+++ b/test_requests.py
@@ -17,7 +17,12 @@ from requests.adapters import HTTPAdapter
 from requests.auth import HTTPDigestAuth, _basic_auth_str
 from requests.compat import (
     Morsel, cookielib, getproxies, str, urljoin, urlparse, is_py3, builtin_str)
-from requests.cookies import cookiejar_from_dict, morsel_to_cookie
+from requests.cookies import (
+    cookiejar_from_dict,
+    morsel_to_cookie,
+    requests_cookie_policy,
+    RequestsCookieJar,
+)
 from requests.exceptions import (ConnectionError, ConnectTimeout,
                                  InvalidSchema, InvalidURL, MissingSchema,
                                  ReadTimeout, Timeout, RetryError)
@@ -1636,6 +1641,26 @@ def test_urllib3_retries():
 
     with pytest.raises(RetryError):
         s.get(httpbin('status/500'))
+
+
+def test_cookie_policy_allows_overriding():
+    DomainLiberal = cookielib.DefaultCookiePolicy.DomainLiberal
+    policy = requests_cookie_policy(strict_ns_domain=DomainLiberal)
+    assert policy.strict_ns_domain == DomainLiberal
+
+
+def test_cookie_policy_defaults_to_strict():
+    policy = requests_cookie_policy()
+    assert isinstance(policy, cookielib.DefaultCookiePolicy)
+    DomainStrict = cookielib.DefaultCookiePolicy.DomainStrict
+    assert policy.strict_ns_domain == DomainStrict
+
+
+def test_cookiejar_policy_defaults_to_strict():
+    jar = RequestsCookieJar()
+    DomainStrict = cookielib.DefaultCookiePolicy.DomainStrict
+    assert jar._policy.strict_ns_domain == DomainStrict
+
 
 def test_vendor_aliases():
     from requests.packages import urllib3


### PR DESCRIPTION
This ensures that we follow RFC 6265 Section 4.1.2.3 appropriately. If a
cookie is returned without a domain attribute, we do not want to send it
to subdomains.

Closes #2576 

---

Needs:
- [ ] Tests
- [ ] Documenting this breaking change
- [ ] Porting to requests-toolbelt for early adopters
- [ ] Backport to master for a 2.x release
