### PR TITLE
Add documentation in "More complicated POST requests" (Quickstart) to resolve #2686

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -229,6 +229,15 @@ For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
     >>> payload = {'some': 'data'}
 
     >>> r = requests.post(url, data=json.dumps(payload))
+    
+You can use the `json` parameter (added in version 2.4.2) to avoid encoding the
+data yourself:
+
+    >>> import json
+    >>> url = 'https://api.github.com/some/endpoint'
+    >>> payload = {'some': 'data'}
+
+    >>> r = requests.post(url, json=payload)
 
 
 POST a Multipart-Encoded File

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -230,8 +230,8 @@ For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
 
     >>> r = requests.post(url, data=json.dumps(payload))
     
-You can use the `json` parameter (added in version 2.4.2) to avoid encoding the
-data yourself:
+Instead of encoding the ``dict`` yourself, you can also pass it directly using
+the ``json`` parameter (added in version 2.4.2) and it will be encoded automatically:
 
     >>> import json
     >>> url = 'https://api.github.com/some/endpoint'


### PR DESCRIPTION
As suggested in #2686, I added a snippet about `requests.post(json=...)` to [Quickstart#More complicated POST requests](http://docs.python-requests.org/en/latest/user/quickstart/#more-complicated-post-requests).