### PR TITLE
Fixed minor rendering issue in documentation code blocks

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -228,9 +228,9 @@ For example, the GitHub API v3 accepts JSON-Encoded POST/PATCH data::
     >>> payload = {'some': 'data'}
 
     >>> r = requests.post(url, data=json.dumps(payload))
-    
+
 Instead of encoding the ``dict`` yourself, you can also pass it directly using
-the ``json`` parameter (added in version 2.4.2) and it will be encoded automatically:
+the ``json`` parameter (added in version 2.4.2) and it will be encoded automatically::
 
     >>> import json
     >>> url = 'https://api.github.com/some/endpoint'
@@ -257,7 +257,7 @@ Requests makes it simple to upload Multipart-encoded files::
       ...
     }
 
-You can set the filename, content_type and headers explicitly:
+You can set the filename, content_type and headers explicitly::
 
     >>> url = 'http://httpbin.org/post'
     >>> files = {'file': ('report.xls', open('report.xls', 'rb'), 'application/vnd.ms-excel', {'Expires': '0'})}


### PR DESCRIPTION
Some of the code blocks on the quickstart page had an issue where they were rendered as two separate `<pre>`, making them inconsitent with the others.

Before:
![quickstart_ _requests_2 7 0_documentation_-_2015-08-15_21 51 01](https://cloud.githubusercontent.com/assets/6345/9290559/22c82672-4398-11e5-8e94-b5cbf2205709.png)

After:
![quickstart_ _requests_2 7 0_documentation_-_2015-08-15_21 51 26](https://cloud.githubusercontent.com/assets/6345/9290558/22c50a3c-4398-11e5-8c6e-51d06aed2090.png)
