### PR TITLE
quick fix to make session cookies work with mocked HTTP responses

### DIFF
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -120,14 +120,16 @@ def extract_cookies_to_jar(jar, request, response):
     :param response: urllib3.HTTPResponse object
     """
     if not (hasattr(response, '_original_response') and
-            response._original_response):
-        return
-    # the _original_response field is the wrapped httplib.HTTPResponse object,
-    req = MockRequest(request)
-    # pull out the HTTPMessage with the headers and put it in the mock:
-    res = MockResponse(response._original_response.msg)
-    jar.extract_cookies(res, req)
+                response._original_response):
+        # just grab the headers from the mocked response object
+        res = MockResponse(response.headers)
+    else:
+        # the _original_response field is the wrapped httplib.HTTPResponse object
+        # pull out the HTTPMessage with the headers and put it in the mock:
+        res = MockResponse(response._original_response.msg)
 
+    req = MockRequest(request)
+    jar.extract_cookies(res, req)
 
 def get_cookie_header(jar, request):
     """Produce an appropriate Cookie header string to be sent with `request`, or None."""


### PR DESCRIPTION
I ran into an issue working with Responses/HTTMock where session cookies were not being set. Tracked it down to here, looked like a quick (possibly dirty?) fix. Doesn't break any tests!

Throwing it up here for wider consideration. Comments welcome.