### PR TITLE
Implement per-host proxies

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -483,7 +483,10 @@ To use HTTP Basic Auth with your proxy, use the `http://user:password@host/` syn
     }
 
 To give a proxy for a specific scheme and host, use the
-`scheme://host` form for the key::
+`scheme://hostname` form for the key.  This will match for
+any request to the given scheme and exact hostname.
+
+::
 
     proxies = {
       "http://10.20.1.128": "http://10.10.1.10:5323",

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -459,17 +459,11 @@ If you need to use a proxy, you can configure individual requests with the
     import requests
 
     proxies = {
-      "http://10.20.1.128": "http://10.10.1.10:5323",
-      "https://10.20.1.140": "http://10.10.1.10:6431"
       "http": "http://10.10.1.10:3128",
       "https": "http://10.10.1.10:1080",
     }
 
     requests.get("http://example.org", proxies=proxies)
-
-A request's ``<scheme>://<hostname>`` is looked up in the proxies
-dictionary first, to provide host-specific proxies.  If no
-host-specific proxy is found, the request's scheme is looked up.
 
 You can also configure proxies by setting the environment variables
 ``HTTP_PROXY`` and ``HTTPS_PROXY``.
@@ -488,8 +482,15 @@ To use HTTP Basic Auth with your proxy, use the `http://user:password@host/` syn
         "http": "http://user:pass@10.10.1.10:3128/",
     }
 
-Note that proxy URLs must include the scheme.
+To give a proxy for a specific scheme and host, use the
+`scheme://host` form for the key::
 
+    proxies = {
+      "http://10.20.1.128": "http://10.10.1.10:5323",
+    }
+
+Note that proxy URLs must include the scheme.
+    
 .. _compliance:
 
 Compliance

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -459,11 +459,17 @@ If you need to use a proxy, you can configure individual requests with the
     import requests
 
     proxies = {
+      "http://10.20.1.128": "http://10.10.1.10:5323",
+      "https://10.20.1.140": "http://10.10.1.10:6431"
       "http": "http://10.10.1.10:3128",
       "https": "http://10.10.1.10:1080",
     }
 
     requests.get("http://example.org", proxies=proxies)
+
+A request's ``<scheme>://<hostname>`` is looked up in the proxies
+dictionary first, to provide host-specific proxies.  If no
+host-specific proxy is found, the request's scheme is looked up.
 
 You can also configure proxies by setting the environment variables
 ``HTTP_PROXY`` and ``HTTPS_PROXY``.

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -239,7 +239,8 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: (optional) A Requests-style dictionary of proxies used on this request.
         """
         proxies = proxies or {}
-        proxy = proxies.get(urlparse(url.lower()).scheme)
+        u = urlparse(url.lower())
+        proxy = proxies.get(u.scheme+'://'+u.hostname, proxies.get(u.scheme))
 
         if proxy:
             proxy = prepend_scheme_if_needed(proxy, 'http')

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -272,7 +272,7 @@ class HTTPAdapter(BaseAdapter):
         :class:`HTTPAdapter <requests.adapters.HTTPAdapter>`.
 
         :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
-        :param proxies: A dictionary of schemes to proxy URLs.
+        :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs.
         """
         proxy = select_proxy(request.url, proxies)
         if proxy and not request.url.lower().startswith('https'):

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -278,10 +278,12 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: A dictionary of schemes to proxy URLs.
         """
         proxies = proxies or {}
-        scheme = urlparse(request.url).scheme
-        proxy = proxies.get(scheme)
+        urlparts = urlparse(request.url.lower())
+        proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
+        if proxy is None:
+            proxy = proxies.get(urlparts.scheme)
 
-        if proxy and scheme != 'https':
+        if proxy and urlparts.scheme != 'https':
             url = urldefragauth(request.url)
         else:
             url = request.path_url

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -275,7 +275,7 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs.
         """
         proxy = select_proxy(request.url, proxies)
-        scheme = urlparse(request.url.lower()).scheme
+        scheme = urlparse(request.url).scheme
         if proxy and scheme != 'https':
             url = urldefragauth(request.url)
         else:

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -275,7 +275,8 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs.
         """
         proxy = select_proxy(request.url, proxies)
-        if proxy and not request.url.lower().startswith('https'):
+        scheme = urlparse(request.url.lower()).scheme
+        if proxy and scheme != 'https':
             url = urldefragauth(request.url)
         else:
             url = request.path_url

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -239,8 +239,10 @@ class HTTPAdapter(BaseAdapter):
         :param proxies: (optional) A Requests-style dictionary of proxies used on this request.
         """
         proxies = proxies or {}
-        u = urlparse(url.lower())
-        proxy = proxies.get(u.scheme+'://'+u.hostname, proxies.get(u.scheme))
+        urlparts = urlparse(url.lower())
+        proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
+        if proxy is None:
+            proxy = proxies.get(urlparts.scheme)
 
         if proxy:
             proxy = prepend_scheme_if_needed(proxy, 'http')

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -299,9 +299,9 @@ class Session(SessionRedirectMixin):
         #: :class:`Request <Request>`.
         self.auth = None
 
-        #: Dictionary mapping protocol to the URL of the proxy (e.g.
-        #: {'http': 'foo.bar:3128'}) to be used on each
-        #: :class:`Request <Request>`.
+        #: Dictionary mapping protocol or protocol and host to the URL of the proxy
+        #: (e.g. {'http': 'foo.bar:3128', 'http://host.name': 'foo.bar:4012'}) to
+        #: be used on each :class:`Request <Request>`.
         self.proxies = {}
 
         #: Event-handling hooks.
@@ -428,8 +428,8 @@ class Session(SessionRedirectMixin):
         :type timeout: float or tuple
         :param allow_redirects: (optional) Set to True by default.
         :type allow_redirects: bool
-        :param proxies: (optional) Dictionary mapping protocol to the URL of
-            the proxy.
+        :param proxies: (optional) Dictionary mapping protocol or protocol and
+            hostname to the URL of the proxy.
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
         :param verify: (optional) if ``True``, the SSL cert will be verified.

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -538,7 +538,11 @@ def get_environ_proxies(url):
         return getproxies()
 
 def select_proxy(url, proxies):
-    """Select a proxy, if applicable."""
+    """Select a proxy for the url, if applicable.
+
+    :param url: The url being for the request
+    :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs
+    """
     proxies = proxies or {}
     urlparts = urlparse(url.lower())
     proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -544,7 +544,7 @@ def select_proxy(url, proxies):
     :param proxies: A dictionary of schemes or schemes and hosts to proxy URLs
     """
     proxies = proxies or {}
-    urlparts = urlparse(url.lower())
+    urlparts = urlparse(url)
     proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
     if proxy is None:
         proxy = proxies.get(urlparts.scheme)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -537,6 +537,14 @@ def get_environ_proxies(url):
     else:
         return getproxies()
 
+def select_proxy(url, proxies):
+    """Select a proxy, if applicable."""
+    proxies = proxies or {}
+    urlparts = urlparse(url.lower())
+    proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
+    if proxy is None:
+        proxy = proxies.get(urlparts.scheme)
+    return proxy
 
 def default_user_agent(name="python-requests"):
     """Return a string representing the default user agent."""

--- a/test_requests.py
+++ b/test_requests.py
@@ -1325,6 +1325,15 @@ class UtilsTestCase(unittest.TestCase):
             'http://localhost.localdomain:5000/v1.0/') == {}
         assert get_environ_proxies('http://www.requests.com/') != {}
 
+    def test_select_proxies(self):
+        """Make sure we can select per-host proxies correctly."""
+        from requests.utils import select_proxy
+        proxies = {'http': 'http://http.proxy',
+                   'http://some.host': 'http://some.host.proxy'}
+        assert select_proxy('hTTp://u:p@Some.Host/path', proxies) == 'http://some.host.proxy'
+        assert select_proxy('hTTp://u:p@Other.Host/path', proxies) == 'http://http.proxy'
+        assert select_proxy('hTTps://Other.Host', proxies) is None
+
     def test_guess_filename_when_int(self):
         from requests.utils import guess_filename
         assert None is guess_filename(1)


### PR DESCRIPTION
This change allows the proxy dict to be have entries of the form
`{'<scheme>://<hostname>': '<proxy>'}`.  Host-specific proxies will be used in
preference to the scheme-specific proxies (i.e., proxy dict entries with keys
like 'http' or 'https').

Fixes #2722