### PR TITLE
Include file-like object in data arg description

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -410,8 +410,8 @@ class Session(SessionRedirectMixin):
         :param url: URL for the new :class:`Request` object.
         :param params: (optional) Dictionary or bytes to be sent in the query
             string for the :class:`Request`.
-        :param data: (optional) Dictionary or bytes to send in the body of the
-            :class:`Request`.
+        :param data: (optional) Dictionary, bytes, or file-like object to send
+            in the body of the :class:`Request`.
         :param json: (optional) json to send in the body of the
             :class:`Request`.
         :param headers: (optional) Dictionary of HTTP Headers to send with the


### PR DESCRIPTION
If `requests.api.request()` uses `requests.sessions.Session.request()` to get it's work done then the data arg description should match between the two.