### PR TITLE
Fix unicode redirects on Python 3.

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -136,8 +136,8 @@ class SessionRedirectMixin(object):
             # urlparse in requote_uri will encode it with UTF-8 before quoting.
             # Because of this insanity, we need to fix it up ourselves by
             # sending the URL back to bytes ourselves.
-            if is_py3 and isinstance(url, str):
-                url = url.encode('latin1')
+            if is_py3 and isinstance(location_url, str):
+                location_url = location_url.encode('latin1')
 
             # Facilitate relative 'location' headers, as allowed by RFC 7231.
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -13,7 +13,7 @@ from collections import Mapping
 from datetime import datetime
 
 from .auth import _basic_auth_str
-from .compat import cookielib, OrderedDict, urljoin, urlparse
+from .compat import cookielib, OrderedDict, urljoin, urlparse, is_py3, str
 from .cookies import (
     cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar, merge_cookies)
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
@@ -131,6 +131,13 @@ class SessionRedirectMixin(object):
             # The scheme should be lower case...
             parsed = urlparse(location_url)
             location_url = parsed.geturl()
+
+            # On Python 3, the location header was decoded using Latin 1, but
+            # urlparse in requote_uri will encode it with UTF-8 before quoting.
+            # Because of this insanity, we need to fix it up ourselves by
+            # sending the URL back to bytes ourselves.
+            if is_py3 and isinstance(url, str):
+                url = url.encode('latin1')
 
             # Facilitate relative 'location' headers, as allowed by RFC 7231.
             # (e.g. '/path/to/resource' instead of 'http://domain.tld/path/to/resource')

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -426,7 +426,7 @@ def unquote_unreserved(uri):
     # This convert function is used to optionally convert the output of `chr`.
     # In Python 3, `chr` returns a unicode string, while in Python 2 it returns
     # a bytestring. Here we deal with that by optionally converting.
-    def _convert(is_bytes, c):
+    def convert(is_bytes, c):
         if is_py2 and not is_bytes:
             return c.decode('ascii')
         elif is_py3 and is_bytes:
@@ -435,14 +435,12 @@ def unquote_unreserved(uri):
             return c
 
     # Handle both bytestrings and unicode strings.
-    if isinstance(uri, bytes):
-        splitchar = b'%'
-        base = b''
-        convert = functools.partial(_convert, True)
-    else:
-        splitchar = u'%'
-        base = u''
-        convert = functools.partial(_convert, False)
+    is_bytes = isinstance(uri, bytes)
+    splitchar = u'%'
+    base = u''
+    if is_bytes:
+        splitchar = splitchar.encode('ascii')
+        base = base.encode('ascii')
 
     parts = uri.split(splitchar)
     for i in range(1, len(parts)):
@@ -454,7 +452,7 @@ def unquote_unreserved(uri):
                 raise InvalidURL("Invalid percent-escape sequence: '%s'" % h)
 
             if c in UNRESERVED_SET:
-                parts[i] = convert(c) + parts[i][2:]
+                parts[i] = convert(is_bytes, c) + parts[i][2:]
             else:
                 parts[i] = splitchar + parts[i]
         else:

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -13,6 +13,7 @@ import cgi
 import codecs
 import collections
 import io
+import functools
 import os
 import platform
 import re
@@ -26,7 +27,7 @@ from . import certs
 from .compat import parse_http_list as _parse_list_header
 from .compat import (quote, urlparse, bytes, str, OrderedDict, unquote, is_py2,
                      builtin_str, getproxies, proxy_bypass, urlunparse,
-                     basestring)
+                     basestring, is_py3)
 from .cookies import RequestsCookieJar, cookiejar_from_dict
 from .structures import CaseInsensitiveDict
 from .exceptions import InvalidURL, FileModeWarning
@@ -422,13 +423,26 @@ def unquote_unreserved(uri):
     """Un-escape any percent-escape sequences in a URI that are unreserved
     characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
     """
+    # This convert function is used to optionally convert the output of `chr`.
+    # In Python 3, `chr` returns a unicode string, while in Python 2 it returns
+    # a bytestring. Here we deal with that by optionally converting.
+    def _convert(is_bytes, c):
+        if is_py2 and not is_bytes:
+            return c.decode('ascii')
+        elif is_py3 and is_bytes:
+            return c.encode('ascii')
+        else:
+            return c
+
     # Handle both bytestrings and unicode strings.
     if isinstance(uri, bytes):
         splitchar = b'%'
         base = b''
+        convert = functools.partial(_convert, True)
     else:
         splitchar = u'%'
         base = u''
+        convert = functools.partial(_convert, False)
 
     parts = uri.split(splitchar)
     for i in range(1, len(parts)):
@@ -440,7 +454,7 @@ def unquote_unreserved(uri):
                 raise InvalidURL("Invalid percent-escape sequence: '%s'" % h)
 
             if c in UNRESERVED_SET:
-                parts[i] = c + parts[i][2:]
+                parts[i] = convert(c) + parts[i][2:]
             else:
                 parts[i] = splitchar + parts[i]
         else:

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -422,7 +422,7 @@ def unquote_unreserved(uri):
     """Un-escape any percent-escape sequences in a URI that are unreserved
     characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
     """
-    parts = uri.split('%')
+    parts = uri.split(b'%')
     for i in range(1, len(parts)):
         h = parts[i][0:2]
         if len(h) == 2 and h.isalnum():

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -13,7 +13,6 @@ import cgi
 import codecs
 import collections
 import io
-import functools
 import os
 import platform
 import re

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -422,7 +422,15 @@ def unquote_unreserved(uri):
     """Un-escape any percent-escape sequences in a URI that are unreserved
     characters. This leaves all reserved, illegal and non-ASCII bytes encoded.
     """
-    parts = uri.split(b'%')
+    # Handle both bytestrings and unicode strings.
+    if isinstance(uri, bytes):
+        splitchar = b'%'
+        base = b''
+    else:
+        splitchar = u'%'
+        base = u''
+
+    parts = uri.split(splitchar)
     for i in range(1, len(parts)):
         h = parts[i][0:2]
         if len(h) == 2 and h.isalnum():
@@ -434,10 +442,10 @@ def unquote_unreserved(uri):
             if c in UNRESERVED_SET:
                 parts[i] = c + parts[i][2:]
             else:
-                parts[i] = '%' + parts[i]
+                parts[i] = splitchar + parts[i]
         else:
-            parts[i] = '%' + parts[i]
-    return ''.join(parts)
+            parts[i] = splitchar + parts[i]
+    return base.join(parts)
 
 
 def requote_uri(uri):

--- a/test_requests.py
+++ b/test_requests.py
@@ -1468,6 +1468,20 @@ class TestUtils:
         quoted = 'http://example.com/fiz?buz=%25ppicture'
         assert quoted == requote_uri(quoted)
 
+    def test_unquote_unreserved_handles_unicode(self):
+        """Unicode strings can be passed to unquote_unreserved"""
+        from requests.utils import unquote_unreserved
+        uri = u'http://example.com/fizz?buzz=%41%2C'
+        unquoted = u'http://example.com/fizz?buzz=A%2C'
+        assert unquoted == unquote_unreserved(uri)
+
+    def test_unquote_unreserved_handles_bytes(self):
+        """Bytestrings can be passed to unquote_unreserved"""
+        from requests.utils import unquote_unreserved
+        uri = b'http://example.com/fizz?buzz=%41%2C'
+        unquoted = b'http://example.com/fizz?buzz=A%2C'
+        assert unquoted == unquote_unreserved(uri)
+
 
 class TestMorselToCookieExpires:
     """Tests for morsel_to_cookie when morsel contains expires."""

--- a/test_requests.py
+++ b/test_requests.py
@@ -1653,7 +1653,7 @@ class TestRedirects:
             assert session.calls[-1] == send_call
 
     @pytest.mark.skipif(is_py2, reason="requires python 3")
-    def test_redirects_with_latin1_header(self):
+    def test_redirects_with_latin1_header(self, httpbin):
         """Test that redirect headers decoded with Latin 1 are correctly
         followed"""
         session = RedirectSession([303])


### PR DESCRIPTION
Resolves #2653.

Follows on from #2655: please read the discussion there for more information.