### PR TITLE
Add PreparedRequest pickling tests

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -802,6 +802,43 @@ class RequestsTestCase(unittest.TestCase):
         assert r.request.url == pr.request.url
         assert r.request.headers == pr.request.headers
 
+    def test_prepared_request_is_pickleable(self):
+        p = requests.Request('GET', httpbin('get')).prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
+    def test_prepared_request_with_file_is_pickleable(self):
+        data = {'a': 0.0}
+        files = {'b': 'foo'}
+        r = requests.Request('POST', httpbin('post'), data=data, files=files)
+        p = r.prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
     def test_get_auth_from_url(self):
         url = 'http://user:pass@complex.url.com/path?query=yes'
         assert ('user', 'pass') == requests.utils.get_auth_from_url(url)

--- a/test_requests.py
+++ b/test_requests.py
@@ -839,6 +839,27 @@ class RequestsTestCase(unittest.TestCase):
 
         assert r.status_code == 200
 
+    def test_prepared_request_with_hook_is_pickleable(self):
+        def print_url(r, *args, **kwargs):
+            print(r.url)
+
+        r = requests.Request('POST', httpbin('post'), hooks=dict(response=print_url))
+        p = r.prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
     def test_get_auth_from_url(self):
         url = 'http://user:pass@complex.url.com/path?query=yes'
         assert ('user', 'pass') == requests.utils.get_auth_from_url(url)


### PR DESCRIPTION
Trying to address #1558 by first creating a failing test, but I'm not sure when `PreparedRequest`s fail to be pickleable. Pulling early to see if anyone has suggestions on how to re-create the issue, also maybe these tests are useful on their own as well.