### PR TITLE
Fix for Json supersedes data in prepare_body #2756

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -414,7 +414,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         content_type = None
         length = None
 
-        if json is not None:
+        if data is None and json is not None:
             content_type = 'application/json'
             body = complexjson.dumps(json)
 
@@ -443,7 +443,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 (body, content_type) = self._encode_files(files, data)
             else:
-                if data and json is None:
+                if data:
                     body = self._encode_params(data)
                     if isinstance(data, basestring) or hasattr(data, 'read'):
                         content_type = None


### PR DESCRIPTION
Now json will be attached to the body only if data is not present. 
(I hope the fix is not more complicated than this.)