### PR TITLE
Fixed issue #2756

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -414,7 +414,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         content_type = None
         length = None
 
-        if json is not None:
+        if not data and json is not None:
             content_type = 'application/json'
             body = complexjson.dumps(json)
 
@@ -443,7 +443,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 (body, content_type) = self._encode_files(files, data)
             else:
-                if data and json is None:
+                if data:
                     body = self._encode_params(data)
                     if isinstance(data, basestring) or hasattr(data, 'read'):
                         content_type = None

--- a/requests/models.py
+++ b/requests/models.py
@@ -414,7 +414,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         content_type = None
         length = None
 
-        if not data and json is not None:
+        if data == {} and json is not None:
             content_type = 'application/json'
             body = complexjson.dumps(json)
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -1062,6 +1062,13 @@ class RequestsTestCase(unittest.TestCase):
         assert 'application/json' in r.request.headers['Content-Type']
         assert {'life': 42} == r.json()['json']
 
+    def test_json_param_post_should_not_override_data_param(self):
+        r = requests.Request(method='POST', url='http://httpbin.org/post',
+                             data={'stuff'.encode('utf-8'): 'elixr'},
+                             json={'music'.encode('utf-8'): 'flute'})
+        prep = r.prepare()
+        assert 'stuff=elixr' == prep.body
+
     def test_response_iter_lines(self):
         r = requests.get(httpbin('stream/4'), stream=True)
         assert r.status_code == 200

--- a/test_requests.py
+++ b/test_requests.py
@@ -1065,7 +1065,7 @@ class RequestsTestCase(unittest.TestCase):
     def test_json_param_post_should_not_override_data_param(self):
         r = requests.Request(method='POST', url='http://httpbin.org/post',
                              data={'stuff'.encode('utf-8'): 'elixr'},
-                             json={'music'.encode('utf-8'): 'flute'})
+                             json={'music': 'flute'})
         prep = r.prepare()
         assert 'stuff=elixr' == prep.body
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -1064,7 +1064,7 @@ class RequestsTestCase(unittest.TestCase):
 
     def test_json_param_post_should_not_override_data_param(self):
         r = requests.Request(method='POST', url='http://httpbin.org/post',
-                             data={'stuff'.encode('utf-8'): 'elixr'},
+                             data={'stuff': 'elixr'},
                              json={'music': 'flute'})
         prep = r.prepare()
         assert 'stuff=elixr' == prep.body


### PR DESCRIPTION
Now 'json' parameter will be used to prepare body only if the 'data'
parameter is not present