### PR TITLE
adapters: Fix bug causing ingored read_timeout for chunked requests

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -1508,6 +1508,19 @@ class TestTimeout:
         except ReadTimeout:
             pass
 
+    def test_read_timeout_chunked(self):
+        def chunked():
+            yield 'foo'
+            yield 'bar'
+
+        try:
+            # note: don't worry, according to HTTP/1.1 spec you actually can
+            #       issue a GET request with a message body
+            requests.get(httpbin('delay/10'), data=chunked(), timeout=(None, .1))
+            assert False, "The recv() request should time out."
+        except ReadTimeout:
+            pass
+
     def test_connect_timeout(self):
         try:
             requests.get(TARPIT, timeout=(0.1, None))

--- a/test_requests.py
+++ b/test_requests.py
@@ -1510,8 +1510,8 @@ class TestTimeout:
 
     def test_read_timeout_chunked(self):
         def chunked():
-            yield 'foo'
-            yield 'bar'
+            yield 'foo'.encode()
+            yield 'bar'.encode()
 
         try:
             # note: don't worry, according to HTTP/1.1 spec you actually can


### PR DESCRIPTION
Whenever chunked request was made (using generators) read timeout value was ignored because socket timeout was not set.

This can be a problem when system default timeout is very long because blocks process waiting for response for a period of time that cannot be controlled.

Changes:

* `HTTPAdapter.send()` now sets read timeout on `low_conn.sock` socket when request body is chunked.
* socket.error, socket.timeout are explicitely translated to urllib3 exceptions using `conn._raise_timeout`
  as expected with non-chunked request bodies to be later translated to `requests` exceptions with existing code.
* test added for timeouts on chunked-message body requests

Additional notes:

* due to convention to use httbin in requests tests and no posibility
 to tests POST timeouts with `delay/:n` endpoint (method not allowed)
 test for this bug uses GET with chunked message-body. This is OK
 because RFC-2616 does not explicitely say that message-body is
 forbidden in GET requests. And also it works