### PR TITLE
Updated Documentation for Issue #2756

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -192,7 +192,7 @@ class Request(RequestHooksMixin):
     :param headers: dictionary of headers to send.
     :param files: dictionary of {filename: fileobject} files to multipart upload.
     :param data: the body to attach to the request. If a dictionary is provided, form-encoding will take place.
-    :param json: json for the body to attach to the request (if data is not specified).
+    :param json: json for the body to attach to the request (if files or data is not specified).
     :param params: dictionary of URL parameters to append to the URL.
     :param auth: Auth handler or (user, pass) tuple.
     :param cookies: dictionary or CookieJar of cookies to attach to this request.


### PR DESCRIPTION
Updated Documentation as mentioned by @taion in #2756 :
```data``` as well as ```files``` supersedes json