### PR TITLE
allows user paths for ca_cert verify path

### DIFF
--- a/requests/packages/urllib3/connection.py
+++ b/requests/packages/urllib3/connection.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import sys
 import socket
 from socket import timeout as SocketTimeout
@@ -198,9 +199,11 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.key_file = key_file
         self.cert_file = cert_file
         self.cert_reqs = cert_reqs
-        self.ca_certs = ca_certs
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
+        if ca_certs:
+            ca_certs = os.path.expanduser(ca_certs)
+        self.ca_certs = ca_certs
 
     def connect(self):
         # Add certificate verification


### PR DESCRIPTION
currently you get the following error:

```SSLError("bad ca_certs: '~/example.crt'", Error([('system library', 'fopen', 'No such file or directory'), ('BIO routines', 'BIO_new_file', 'no such file'), ('x509 certificate routines', 'X509_load_cert_crl_file', 'system lib')],))```