### PR TITLE
Don't treat NewConnectionErrors as timeouts.

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -24,6 +24,7 @@ from .packages.urllib3.exceptions import ClosedPoolError
 from .packages.urllib3.exceptions import ConnectTimeoutError
 from .packages.urllib3.exceptions import HTTPError as _HTTPError
 from .packages.urllib3.exceptions import MaxRetryError
+from .packages.urllib3.exceptions import NewConnectionError
 from .packages.urllib3.exceptions import ProxyError as _ProxyError
 from .packages.urllib3.exceptions import ProtocolError
 from .packages.urllib3.exceptions import ReadTimeoutError
@@ -412,7 +413,9 @@ class HTTPAdapter(BaseAdapter):
 
         except MaxRetryError as e:
             if isinstance(e.reason, ConnectTimeoutError):
-                raise ConnectTimeout(e, request=request)
+                # TODO: Remove this in 3.0.0: see #2811
+                if not isinstance(e.reason, NewConnectionError):
+                    raise ConnectTimeout(e, request=request)
 
             if isinstance(e.reason, ResponseError):
                 raise RetryError(e, request=request)


### PR DESCRIPTION
Resolves #2811.

Fundamentally I view this mostly as a compatibility change, to get us back into line with how we've processed this kind of error in the 2.X series. I think I'd like to back it out in 3.0.0, which is why I've left a note in the code to that effect.