### PR TITLE
Allow non-native-string method names.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -319,7 +319,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         """Prepares the given HTTP method."""
         self.method = method
         if self.method is not None:
-            self.method = self.method.upper()
+            self.method = to_native_string(self.method.upper())
 
     def prepare_url(self, url, params):
         """Prepares the given HTTP URL."""

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -438,9 +438,6 @@ class Session(SessionRedirectMixin):
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         """
-
-        method = to_native_string(method)
-
         # Create the Request.
         req = Request(
             method = method.upper(),

--- a/test_requests.py
+++ b/test_requests.py
@@ -568,6 +568,17 @@ class RequestsTestCase(unittest.TestCase):
             method=u('POST'), url=httpbin('post'), files=files)
         assert r.status_code == 200
 
+    def test_unicode_method_name_with_request_object(self):
+        files = {'file': open('test_requests.py', 'rb')}
+        s = requests.Session()
+        req = requests.Request(u("POST"), httpbin('post'), files=files)
+        prep = s.prepare_request(req)
+        assert isinstance(prep.method, builtin_str)
+        assert prep.method == "POST"
+
+        resp = s.send(prep)
+        assert resp.status_code == 200
+
     def test_custom_content_type(self):
         r = requests.post(
             httpbin('post'),


### PR DESCRIPTION
Resolves #2818.