### PR TITLE
Fixed usage example in sessions.py

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -273,13 +273,13 @@ class Session(SessionRedirectMixin):
       >>> import requests
       >>> s = requests.Session()
       >>> s.get('http://httpbin.org/get')
-      200
+      <Response [200]>
 
     Or as a context manager::
 
       >>> with requests.Session() as s:
       >>>     s.get('http://httpbin.org/get')
-      200
+      <Response [200]>
     """
 
     __attrs__ = [


### PR DESCRIPTION
The usage example for sessions.py's Session class is not correct in my opinion. The get method in fact returns a `Response <Response>` object, the notation "200" may be misleading the user into thinking only the http statuscode will be returned. Furthermore the output you get on console if typing the example in is different from the example and similar to my change.

The two usage examples in models.py are also similar to my change.

Thank you for considering.