### PR TITLE
Use buffering for HTTP responses on chunked requests

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -394,7 +394,15 @@ class HTTPAdapter(BaseAdapter):
                         low_conn.send(b'\r\n')
                     low_conn.send(b'0\r\n\r\n')
 
-                    r = low_conn.getresponse()
+                    # Receive the response from the server
+                    try:
+                        # For Python 2.7+ versions, use buffering of HTTP
+                        # responses
+                        r = conn.getresponse(buffering=True)
+                    except TypeError:
+                        # For compatibility with Python 2.6 versions and back
+                        r = conn.getresponse()
+
                     resp = HTTPResponse.from_httplib(
                         r,
                         pool=conn,


### PR DESCRIPTION
For non-chunked requests, the request is performed using the 'urlopen'
method that underlying uses buffering for the HTTP responses (for Python
2.7+ versions). For chunked requests though, the request is made via a
different code path and so the 'getresponse' method is called without
using buffering. So, the response is consumed per single byte via a
recv() call on the underlying socket.

This patch, fixes that issue to mimic the non-chucked request behavior.