### PR TITLE
Check Content-Length when present.

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -97,3 +97,7 @@ class StreamConsumedError(RequestException, TypeError):
 
 class RetryError(RequestException):
     """Custom retries logic failed"""
+
+
+class TruncatedContentError(RequestException):
+    """Content body received is shorter than declared Content-Length"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 py==1.4.30
 pytest==2.8.1
 pytest-cov==2.1.0
+mock
 wheel


### PR DESCRIPTION
This is pretty hard to reproduce, but I have seen truncated responses in the presence of connection resets that are silently ignored by requests.

This link describes how the vagaries of TCP and socket API may return an error or 0 (end-of-file) when the stars align just right:
  http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable

This patch checks that the number of bytes read matches the declared Content-Length (when declared). I'm not an HTTP expert, so I may be missing something, but I hope this is useful. This also only covers the urllib3 code path.