### PR TITLE
Use session.verify

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -455,6 +455,9 @@ class Session(SessionRedirectMixin):
 
         proxies = proxies or {}
 
+        if verify is None:
+            verify = self.verify
+
         settings = self.merge_environment_settings(
             prep.url, proxies, stream, verify, cert
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+mock
+contextlib2
 py==1.4.30
 pytest==2.8.1
 pytest-cov==2.1.0


### PR DESCRIPTION
session.verify is currently ignored. Didn't have time for a unit test, but this is one solution.