### PR TITLE
Make sure we build environment settings properly.

### DIFF
--- a/test_requests.py
+++ b/test_requests.py
@@ -1156,7 +1156,7 @@ class TestRequests:
         next(r.iter_lines())
         assert len(list(r.iter_lines())) == 3
 
-    def test_environment_comes_after_session(self):
+    def test_environment_comes_after_session(self, httpbin):
         """The Session arguments should come before environment arguments."""
         # We get proxies from the environment and verify from the argument.
         s = requests.Session()


### PR DESCRIPTION
Resolves #2836.

This actually requires a slightly tricky re-ordering here: the proxies work needs to happen separately to make sure keys set to `None` DTRT.