### PR TITLE
Added Travis support with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ nosetests.xml
 junit-report.xml
 pylint.txt
 toy.py
-tox.ini
 violations.pyflakes.txt
 cover/
 build/
@@ -22,3 +21,5 @@ t.py
 
 t2.py
 dist
+.cache/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "pypy"
+
+install:
+  - pip install tox
+  - tox -e $TRAVIS_PYTHON_VERSION --notest
+
+script: tox -e $TRAVIS_PYTHON_VERSION
+# after_success: coveralls $COVERALLS_OPTION

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -161,3 +161,4 @@ Patches and Suggestions
 - Colin Dickson (`@colindickson <https://github.com/colindickson>`_)
 - Smiley Barry (`@smiley <https://github.com/smiley>`_)
 - Shagun Sodhani (`@shagunsodhani <https://github.com/shagunsodhani>`_)
+- Anthony Monthe <anthony.monthe@gmail.com> (`@ZuluPro <https://github.com/ZuluPro>`_)

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,9 @@ Requests: HTTP for Humans
 .. image:: https://img.shields.io/pypi/dm/requests.svg
         :target: https://pypi.python.org/pypi/requests
 
-
+.. image:: https://api.travis-ci.org/kennethreitz/requests.svg
+        :target: https://travis-ci.org/kennethreitz/requests
+        :alt: Travis build
 
 
 Requests is an Apache2 Licensed HTTP library, written in Python, for human

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 py==1.4.30
 pytest==2.8.1
 pytest-cov==2.1.0
+coverage<4
 wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = 2.6,2.7,pypy,3.3,3.4,3.5
+
+[testenv]
+basepython =
+    2.6: python2.6
+    2.7: python2.7
+    pypy: pypy
+    3.3: python3.3
+    3.4: python3.4
+    3.5: python3.5
+deps =
+    -r{toxinidir}/requirements.txt
+commands = {posargs:py.test test_requests.py --verbose --cov-report term --cov=requests test_requests.py}


### PR DESCRIPTION
- Added `.travis.yml`
I think it is useful for every contributors to have a online tool for test.
I added Travis' badge in `README.rst``
Maybe you want to add Coveralls support in future ?

- Added `tox.ini`
I implement tox usage for simplify tests across Python versions.
Maybe you want to add documentation tests in future ?

There are two errors (don't come from my commit) and the build is failing...
```
____________ RequestsTestCase.test_BASICAUTH_TUPLE_HTTP_200_OK_GET _____________
self = <test_requests.RequestsTestCase testMethod=test_BASICAUTH_TUPLE_HTTP_200_OK_GET>
    def test_BASICAUTH_TUPLE_HTTP_200_OK_GET(self):
        auth = ('user', 'pass')
        url = httpbin('basic-auth', 'user', 'pass')
    
        r = requests.get(url, auth=auth)
        assert r.status_code == 200
    
        r = requests.get(url)
>       assert r.status_code == 401
E       AssertionError: assert 200 == 401
E        +  where 200 = <Response [200]>.status_code
test_requests.py:317: AssertionError
_________ RequestsTestCase.test_auth_is_stripped_on_redirect_off_host __________
self = <test_requests.RequestsTestCase testMethod=test_auth_is_stripped_on_redirect_off_host>
    def test_auth_is_stripped_on_redirect_off_host(self):
        r = requests.get(
            httpbin('redirect-to'),
            params={'url': 'http://www.google.co.uk'},
            auth=('user', 'pass'),
        )
        assert r.history[0].request.headers['Authorization']
>       assert not r.request.headers.get('Authorization', '')
E       AssertionError: assert not 'Basic dXNlcjpwYXNz'
E        +  where 'Basic dXNlcjpwYXNz' = <bound method CaseInsensitiveDict.get of {'Authorization': 'Basic dXNlcjpwYXNz...ing': 'gzip, deflate', 'User-Agent': 'python-requests/2.8.1', 'Accept': '*/*'}>('Authorization', '')
E        +    where <bound method CaseInsensitiveDict.get of {'Authorization': 'Basic dXNlcjpwYXNz...ing': 'gzip, deflate', 'User-Agent': 'python-requests/2.8.1', 'Accept': '*/*'}> = {'Authorization': 'Basic dXNlcjpwYXNz', 'Connection': 'keep-alive', 'Accept-Encoding': 'gzip, deflate', 'User-Agent': 'python-requests/2.8.1', 'Accept': '*/*'}.get
E        +      where {'Authorization': 'Basic dXNlcjpwYXNz', 'Connection': 'keep-alive', 'Accept-Encoding': 'gzip, deflate', 'User-Agent': 'python-requests/2.8.1', 'Accept': '*/*'} = <PreparedRequest [GET]>.headers
E        +        where <PreparedRequest [GET]> = <Response [200]>.request
```