### PR TITLE
Fix breakage introduced by 8f591682

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -398,10 +398,10 @@ class HTTPAdapter(BaseAdapter):
                     try:
                         # For Python 2.7+ versions, use buffering of HTTP
                         # responses
-                        r = conn.getresponse(buffering=True)
+                        r = low_conn.getresponse(buffering=True)
                     except TypeError:
                         # For compatibility with Python 2.6 versions and back
-                        r = conn.getresponse()
+                        r = low_conn.getresponse()
 
                     resp = HTTPResponse.from_httplib(
                         r,

--- a/test_requests.py
+++ b/test_requests.py
@@ -1133,6 +1133,13 @@ class TestRequests(object):
         next(r.iter_lines())
         assert len(list(r.iter_lines())) == 3
 
+    def test_chunked_upload(self, httpbin):
+        """Can safely send generators."""
+        data = (c for c in 'abc')
+        r = requests.post(httpbin('post'), data=data, stream=True)
+        assert r.status_code == 200
+        assert r.request.headers['Transfer-Encoding'] == 'chunked'
+
 
 class TestContentEncodingDetection(unittest.TestCase):
 

--- a/test_requests.py
+++ b/test_requests.py
@@ -1133,13 +1133,6 @@ class TestRequests(object):
         next(r.iter_lines())
         assert len(list(r.iter_lines())) == 3
 
-    def test_chunked_upload(self, httpbin):
-        """Can safely send generators."""
-        data = (c for c in 'abc')
-        r = requests.post(httpbin('post'), data=data, stream=True)
-        assert r.status_code == 200
-        assert r.request.headers['Transfer-Encoding'] == 'chunked'
-
 
 class TestContentEncodingDetection(unittest.TestCase):
 


### PR DESCRIPTION
Turns out we broke chunked uploads in 8f591682e6a901baf0cc8a0393b5930252f0318a. I discovered this while investigating #2215.

While we were here, I added a test that would at least have caught errors as egregious as this one.