### PR TITLE
cache Response.text

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -753,31 +753,33 @@ class Response(object):
         non-HTTP knowledge to make a better guess at the encoding, you should
         set ``r.encoding`` appropriately before accessing this property.
         """
+        if not hasattr(self, '_text'):
+            if not self.content:
+                self._text = str('')
 
-        # Try charset from content-type
-        content = None
-        encoding = self.encoding
+            else:
+                # Try charset from content-type
+                encoding = self.encoding
 
-        if not self.content:
-            return str('')
+                # Fallback to auto-detected encoding.
+                if self.encoding is None:
+                    encoding = self.apparent_encoding
 
-        # Fallback to auto-detected encoding.
-        if self.encoding is None:
-            encoding = self.apparent_encoding
+                # Decode unicode from given encoding.
+                try:
+                    content = str(self.content, encoding, errors='replace')
+                except (LookupError, TypeError):
+                    # A LookupError is raised if the encoding was not found which could
+                    # indicate a misspelling or similar mistake.
+                    #
+                    # A TypeError can be raised if encoding is None
+                    #
+                    # So we try blindly encoding.
+                    content = str(self.content, errors='replace')
 
-        # Decode unicode from given encoding.
-        try:
-            content = str(self.content, encoding, errors='replace')
-        except (LookupError, TypeError):
-            # A LookupError is raised if the encoding was not found which could
-            # indicate a misspelling or similar mistake.
-            #
-            # A TypeError can be raised if encoding is None
-            #
-            # So we try blindly encoding.
-            content = str(self.content, errors='replace')
+                self._text = content
 
-        return content
+        return self._text
 
     def json(self, **kwargs):
         """Returns the json-encoded content of a response, if any.


### PR DESCRIPTION
`Response.text` is a pure function, seems pointless doing the same conversions in repeated calls. 

Cached
```
In [4]: %timeit any(word in resp.text for word in words)
The slowest run took 6.20 times longer than the fastest. This could mean that an intermediate result is being cached 
100000 loops, best of 3: 17.4 µs per loop
```

Not cached
```
In [5]: %timeit any(word in resp.text_old for word in words)                                                                            
10000 loops, best of 3: 64.4 µs per loop
```

`len(words) == 3` in these examples, in a real world use case it could be much longer.

