### PR TITLE
Specify minimum pyOpenSSL version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,6 @@ setup(
         'Programming Language :: Python :: 3.5',
     ),
     extras_require={
-        'security': ['pyOpenSSL', 'ndg-httpsclient', 'pyasn1'],
+        'security': ['pyOpenSSL>=0.13', 'ndg-httpsclient', 'pyasn1'],
     },
 )


### PR DESCRIPTION
urllib3 requires "set_tlsext_host_name" which was only added in
pyOpenSSL 0.13. As some distributions (e.g. Ubuntu 12.04) still ship an
older version enforce the correct minimum version during installation.

I will submit a similar pull requests to the urllib3 project.