### PR TITLE
requests/auth: Handle an empty 'qop' attribute in an Authenticate challenge

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -136,7 +136,7 @@ class HTTPDigestAuth(AuthBase):
         if _algorithm == 'MD5-SESS':
             HA1 = hash_utf8('%s:%s:%s' % (HA1, nonce, cnonce))
 
-        if qop is None:
+        if not qop:
             respdig = KD(HA1, "%s:%s" % (nonce, HA2))
         elif qop == 'auth' or 'auth' in qop.split(','):
             noncebit = "%s:%s:%s:%s:%s" % (


### PR DESCRIPTION
Some malfunctioning HTTP servers may return a qop directive with no token, as
opposed to correctly omitting the qop directive completely. For example:

```
header: WWW-Authenticate: Digest realm="foobar_api_auth", qop="",
        nonce="a12059eaaad0b86ece8f62f04cbafed6", algorithm="MD5",
        stale="false"
```

Prior to this patch, requests would respond with a 'None' Authorization header.
While the server is certainly incorrect, this patch updates requests to be
more tolerant to this kind of shenaniganry. If we receive an empty string for
the value of the qop attribute, or some tokens that are not recognized (that
is, not 'auth' or 'auth-int'), we instead treat that as if the qop attribute
was simply not provided.

Closes #2916