### PR TITLE
Add hint to :param verify.

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -434,7 +434,7 @@ class Session(SessionRedirectMixin):
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
         :param verify: (optional) if ``True``, the SSL cert will be verified.
-            A CA_BUNDLE path can also be provided.
+            A CA_BUNDLE path can also be provided. Defaults to ``True``.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         """


### PR DESCRIPTION
It is not clear that :param verify defaults to True. The way the verify
portion of the docstring is written it looks like it defaults to False, and
you have to pass in True if you'd like the SSL cert to be verified, but the
opposite is the case.