### PR TITLE
Refactor default params

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -162,3 +162,4 @@ Patches and Suggestions
 - Smiley Barry (`@smiley <https://github.com/smiley>`_)
 - Shagun Sodhani (`@shagunsodhani <https://github.com/shagunsodhani>`_)
 - Robin Linderborg (`@vienno <https://github.com/vienno>`_)
+- Brian Samek(`@bsamek <https://github.com/bsamek`_)

--- a/requests/api.py
+++ b/requests/api.py
@@ -33,7 +33,7 @@ def request(method, url, **kwargs):
     :param allow_redirects: (optional) Boolean. Set to True if POST/PUT/DELETE redirect following is allowed.
     :type allow_redirects: bool
     :param proxies: (optional) Dictionary mapping protocol to the URL of the proxy.
-    :param verify: (optional) if ``True``, the SSL cert will be verified. A CA_BUNDLE path can also be provided.
+    :param verify: (optional) whether the SSL cert will be verified. A CA_BUNDLE path can also be provided. Defaults to ``True``.
     :param stream: (optional) if ``False``, the response content will be immediately downloaded.
     :param cert: (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.
     :return: :class:`Response <Response>` object

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -400,8 +400,8 @@ class Session(SessionRedirectMixin):
         allow_redirects=True,
         proxies=None,
         hooks=None,
-        stream=False,
-        verify=True,
+        stream=None,
+        verify=None,
         cert=None,
         json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -400,8 +400,8 @@ class Session(SessionRedirectMixin):
         allow_redirects=True,
         proxies=None,
         hooks=None,
-        stream=None,
-        verify=None,
+        stream=False,
+        verify=True,
         cert=None,
         json=None):
         """Constructs a :class:`Request <Request>`, prepares it and sends it.
@@ -433,7 +433,7 @@ class Session(SessionRedirectMixin):
             hostname to the URL of the proxy.
         :param stream: (optional) whether to immediately download the response
             content. Defaults to ``False``.
-        :param verify: (optional) if ``True``, the SSL cert will be verified.
+        :param verify: (optional) whether the SSL cert will be verified.
             A CA_BUNDLE path can also be provided. Defaults to ``True``.
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.


### PR DESCRIPTION
Specified the default argument for params that have a default in the docstring
so that the default is easier to see from the code. Modified the docstring in
api.py to match the docstring in sessions.py.