### PR TITLE
Handle bytes and unicode URLs for netloc

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -116,7 +116,10 @@ def get_netrc_auth(url, raise_errors=False):
         ri = urlparse(url)
 
         # Strip port numbers from netloc
-        host = ri.netloc.split(':')[0]
+        if isinstance(url, str):
+            host = ri.netloc.split(u':')[0]
+        else:
+            host = ri.netloc.split(b':')[0]
 
         try:
             _netrc = netrc(netrc_path).authenticators(host)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -115,11 +115,12 @@ def get_netrc_auth(url, raise_errors=False):
 
         ri = urlparse(url)
 
-        # Strip port numbers from netloc
+        # Strip port numbers from netloc. This weird `if...encode`` dance is
+        # used for Python 3.2, which doesn't support unicode literals.
+        splitstr = b':'
         if isinstance(url, str):
-            host = ri.netloc.split(u':')[0]
-        else:
-            host = ri.netloc.split(b':')[0]
+            splitstr = splitstr.decode('ascii')
+        host = ri.netloc.split(splitstr)[0]
 
         try:
             _netrc = netrc(netrc_path).authenticators(host)


### PR DESCRIPTION
Spotted this on my local machine running tests on Python 3. Annoyingly, we didn't see this on the CI rig because the Jenkins box doesn't have a netrc file, so it never gets that far in the function.

However, tests preparing bytes URLs fail here on Python 3 because the splitter is the wrong type. This change ensures that we use the appropriate type.

Feels like this is safe for 2.9.1.