### PR TITLE
Clarification of .netrc and auth= precedence

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -197,7 +197,8 @@ For example, we didn't specify our user-agent in the previous example::
 
 Note: Custom headers are given less precedence than more specific sources of information. For instance:
 
-* Authorization headers will be overridden if credentials are passed via the ``auth`` parameter or are specified in a ``.netrc`` accessible in the environment.
+* Authorization headers will be overridden if credentials are specified in ``.netrc`` 
+accessible in the environment. That in turn will be overridden by the  ``auth=`` parameter.
 * Authorization headers will be removed if you get redirected off-host.
 * Proxy-Authorization headers will be overridden by proxy credentials provided in the URL.
 * Content-Length headers will be overridden when we can determine the length of the content.


### PR DESCRIPTION
This closes #2062 by clarifying which auth header takes precedence:
1. auth=
2. .netrc
3. headers=