### PR TITLE
Discard 0-byte chunks from request body iterators

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -162,4 +162,5 @@ Patches and Suggestions
 - Smiley Barry (`@smiley <https://github.com/smiley>`_)
 - Shagun Sodhani (`@shagunsodhani <https://github.com/shagunsodhani>`_)
 - Robin Linderborg (`@vienno <https://github.com/vienno>`_)
-- Brian Samek(`@bsamek <https://github.com/bsamek`_)
+- Brian Samek (`@bsamek <https://github.com/bsamek>`_)
+- Tim Burke (`@tipabu <https://github.com/tipabu>`_)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -394,6 +394,8 @@ class HTTPAdapter(BaseAdapter):
                     low_conn.endheaders()
 
                     for i in request.body:
+                        if len(i) == 0:
+                            continue
                         low_conn.send(hex(len(i))[2:].encode('utf-8'))
                         low_conn.send(b'\r\n')
                         low_conn.send(i)


### PR DESCRIPTION
Previously, an empty chunk in a request body iterator would be
faithfully translated to a 0-length chunk on the wire, which the server
would interpret as the end of the transfer. That is, a request like

    def data():
        yield 'foo'
        yield ''
        yield 'bar'
    requests.put(url, data=data())

... would cause the server to receive a chunk for 'foo', receive an
empty chunk, and close the connection before receiving 'bar'.

Further, if `Connection: keep-alive` is set, the server will attempt (and
fail) to parse the next chunk, serve a 400, and close the connection.

Now, the empty chunk will be ignored, and the server should receive all
of the actual bytes emitted from the iterable.