### PR TITLE
Rename {Missing,Invalid}Schema to *Scheme

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -251,7 +251,7 @@ API Changes
       }
 
       # In requests 1.x, this was legal, in requests 2.x,
-      #  this raises requests.exceptions.MissingSchema
+      #  this raises requests.exceptions.MissingScheme
       requests.get("http://example.org", proxies=proxies)
 
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -71,12 +71,12 @@ class TooManyRedirects(RequestException):
     """Too many redirects."""
 
 
-class MissingSchema(RequestException, ValueError):
-    """The URL schema (e.g. http or https) is missing."""
+class MissingScheme(RequestException, ValueError):
+    """The URL scheme (e.g. http or https) is missing."""
 
 
-class InvalidSchema(RequestException, ValueError):
-    """See defaults.py for valid schemas."""
+class InvalidScheme(RequestException, ValueError):
+    """See defaults.py for valid schemes."""
 
 
 class InvalidURL(RequestException, ValueError):

--- a/requests/models.py
+++ b/requests/models.py
@@ -22,7 +22,7 @@ from .packages.urllib3.util import parse_url
 from .packages.urllib3.exceptions import (
     DecodeError, ReadTimeoutError, ProtocolError, LocationParseError)
 from .exceptions import (
-    HTTPError, MissingSchema, InvalidURL, ChunkedEncodingError,
+    HTTPError, MissingScheme, InvalidURL, ChunkedEncodingError,
     ContentDecodingError, ConnectionError, StreamConsumedError)
 from .utils import (
     guess_filename, get_auth_from_url, requote_uri,
@@ -358,7 +358,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             raise InvalidURL(*e.args)
 
         if not scheme:
-            raise MissingSchema("Invalid URL {0!r}: No schema supplied. "
+            raise MissingScheme("Invalid URL {0!r}: No scheme supplied. "
                                 "Perhaps you meant http://{0}?".format(
                                     to_native_string(url, 'utf8')))
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -20,7 +20,7 @@ from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
 from .hooks import default_hooks, dispatch_hook
 from .utils import to_key_val_list, default_headers, to_native_string
 from .exceptions import (
-    TooManyRedirects, InvalidSchema, ChunkedEncodingError, ContentDecodingError)
+    TooManyRedirects, InvalidScheme, ChunkedEncodingError, ContentDecodingError)
 from .packages.urllib3._collections import RecentlyUsedContainer
 from .structures import CaseInsensitiveDict
 
@@ -635,7 +635,7 @@ class Session(SessionRedirectMixin):
                 return adapter
 
         # Nothing matches :-/
-        raise InvalidSchema("No connection adapters were found for '%s'" % url)
+        raise InvalidScheme("No connection adapters were found for '%s'" % url)
 
     def close(self):
         """Closes all adapters and as such the session"""

--- a/test_requests.py
+++ b/test_requests.py
@@ -19,7 +19,7 @@ from requests.compat import (
     Morsel, cookielib, getproxies, str, urljoin, urlparse, is_py3, builtin_str)
 from requests.cookies import cookiejar_from_dict, morsel_to_cookie
 from requests.exceptions import (ConnectionError, ConnectTimeout,
-                                 InvalidSchema, InvalidURL, MissingSchema,
+                                 InvalidScheme, InvalidURL, MissingScheme,
                                  ReadTimeout, Timeout, RetryError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
@@ -77,13 +77,13 @@ class RequestsTestCase(unittest.TestCase):
         requests.post
 
     def test_invalid_url(self):
-        with pytest.raises(MissingSchema):
+        with pytest.raises(MissingScheme):
             requests.get('hiwpefhipowhefopw')
-        with pytest.raises(InvalidSchema):
+        with pytest.raises(InvalidScheme):
             requests.get('localhost:3128')
-        with pytest.raises(InvalidSchema):
+        with pytest.raises(InvalidScheme):
             requests.get('localhost.localdomain:3128/')
-        with pytest.raises(InvalidSchema):
+        with pytest.raises(InvalidScheme):
             requests.get('10.122.1.1:3128/')
         with pytest.raises(InvalidURL):
             requests.get('http://')


### PR DESCRIPTION
As @merwok pointed out at https://github.com/kennethreitz/requests/pull/512#commitcomment-1296187, schemes are what they're called, not schemas. I got tripped up by this at https://github.com/CenterForOpenScience/osf.io/pull/4745#issuecomment-169038417, where "InvalidSchema" made me think I was hitting a database error, when in fact it was a configuration error in the format of a URL.

This PR is a redo of #2960 against `proposed/3.0.0` instead of `master`.