### PR TITLE
Return request & response with TooManyRedirects

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -110,7 +110,11 @@ class SessionRedirectMixin(object):
                 resp.raw.read(decode_content=False)
 
             if i >= self.max_redirects:
-                raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects)
+                raise TooManyRedirects(
+                    'Exceeded %s redirects.' % self.max_redirects,
+                    request=prepared_request,
+                    response=resp
+                )
 
             # Release the connection back into the pool.
             resp.close()

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -110,11 +110,7 @@ class SessionRedirectMixin(object):
                 resp.raw.read(decode_content=False)
 
             if i >= self.max_redirects:
-                raise TooManyRedirects(
-                    'Exceeded %s redirects.' % self.max_redirects,
-                    request=prepared_request,
-                    response=resp
-                )
+                raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects, response=resp)
 
             # Release the connection back into the pool.
             resp.close()

--- a/test_requests.py
+++ b/test_requests.py
@@ -24,7 +24,7 @@ from requests.cookies import cookiejar_from_dict, morsel_to_cookie
 from requests.exceptions import (ConnectionError, ConnectTimeout,
                                  InvalidSchema, InvalidURL, MissingSchema,
                                  ReadTimeout, Timeout, RetryError, TooManyRedirects)
-from requests.models import PreparedRequest, DEFAULT_REDIRECT_LIMIT
+from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin
 from requests.models import urlencode
@@ -192,10 +192,11 @@ class TestRequests(object):
         try:
             requests.get(httpbin('redirect', '50'))
         except TooManyRedirects as e:
-            assert e.request is not None
-            assert len(e.response.history) == DEFAULT_REDIRECT_LIMIT
+            assert '/relative-redirect/20' in e.request.url
+            assert e.request.url == e.response.url
+            assert len(e.response.history) == 30
         else:
-            assert False
+            pytest.fail()
 
     def test_HTTP_302_TOO_MANY_REDIRECTS_WITH_PARAMS(self, httpbin):
         s = requests.session()
@@ -203,10 +204,11 @@ class TestRequests(object):
         try:
             s.get(httpbin('redirect', '50'))
         except TooManyRedirects as e:
-            assert e.request is not None
+            assert '/relative-redirect/45' in e.request.url
+            assert e.request.url == e.response.url
             assert len(e.response.history) == 5
         else:
-            assert False
+            pytest.fail()
 
     # def test_HTTP_302_ALLOW_REDIRECT_POST(self):
     #     r = requests.post(httpbin('status', '302'), data={'some': 'data'})

--- a/test_requests.py
+++ b/test_requests.py
@@ -191,7 +191,7 @@ class TestRequests(object):
     def test_HTTP_302_TOO_MANY_REDIRECTS(self, httpbin):
         try:
             requests.get(httpbin('redirect', '50'))
-        except TooManyRedirects, e:
+        except TooManyRedirects as e:
             assert e.request is not None
             assert len(e.response.history) == DEFAULT_REDIRECT_LIMIT
         else:
@@ -202,7 +202,7 @@ class TestRequests(object):
         s.max_redirects = 5
         try:
             s.get(httpbin('redirect', '50'))
-        except TooManyRedirects, e:
+        except TooManyRedirects as e:
             assert e.request is not None
             assert len(e.response.history) == 5
         else:

--- a/test_requests.py
+++ b/test_requests.py
@@ -190,10 +190,11 @@ class TestRequests(object):
 
     def test_HTTP_302_TOO_MANY_REDIRECTS(self, httpbin):
         try:
-            requests.get(httpbin('redirect', '50'))
+            requests.get(httpbin('relative-redirect', '50'))
         except TooManyRedirects as e:
-            assert '/relative-redirect/20' in e.request.url
-            assert e.request.url == e.response.url
+            url = httpbin('relative-redirect', '20')
+            assert e.request.url == url
+            assert e.response.url == url
             assert len(e.response.history) == 30
         else:
             pytest.fail('Expected redirect to raise TooManyRedirects but it did not')
@@ -202,13 +203,14 @@ class TestRequests(object):
         s = requests.session()
         s.max_redirects = 5
         try:
-            s.get(httpbin('redirect', '50'))
+            s.get(httpbin('relative-redirect', '50'))
         except TooManyRedirects as e:
-            assert '/relative-redirect/45' in e.request.url
-            assert e.request.url == e.response.url
+            url = httpbin('relative-redirect', '45')
+            assert e.request.url == url
+            assert e.response.url == url
             assert len(e.response.history) == 5
         else:
-            pytest.fail('Expected redirect to raise TooManyRedirects but it did not')
+            pytest.fail('Expected custom max number of redirects to be respected but was not')
 
     # def test_HTTP_302_ALLOW_REDIRECT_POST(self):
     #     r = requests.post(httpbin('status', '302'), data={'some': 'data'})

--- a/test_requests.py
+++ b/test_requests.py
@@ -196,7 +196,7 @@ class TestRequests(object):
             assert e.request.url == e.response.url
             assert len(e.response.history) == 30
         else:
-            pytest.fail()
+            pytest.fail('Expected redirect to raise TooManyRedirects but it did not')
 
     def test_HTTP_302_TOO_MANY_REDIRECTS_WITH_PARAMS(self, httpbin):
         s = requests.session()
@@ -208,7 +208,7 @@ class TestRequests(object):
             assert e.request.url == e.response.url
             assert len(e.response.history) == 5
         else:
-            pytest.fail()
+            pytest.fail('Expected redirect to raise TooManyRedirects but it did not')
 
     # def test_HTTP_302_ALLOW_REDIRECT_POST(self):
     #     r = requests.post(httpbin('status', '302'), data={'some': 'data'})


### PR DESCRIPTION
I'm using requests to fetch data from websites that I don't maintain, and sometimes websites have broken cyclic redirects, but still return useful responses.  So I would like to grab the last cut off response, similar to the browser.

The problem is that `TooManyRedirects` doesn't throw the ending response state for me to inspect, so this PR adds that.