### PR TITLE
Stop falling back to distutils in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ import sys
 
 from codecs import open
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
+
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
distutils has been deprecated for years now and pip is refusing to install
projects using it. As such, *some* users are reporting problems installing
requests. Let's avoid this entirely by not falling back to distutils at all.