### PR TITLE
Fix api doc of debug logging for Python 3

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,11 +184,13 @@ API Changes
       import requests
       import logging
 
-      # these two lines enable debugging at http.client level (requests->urllib3->http.client)
+      # Enabling debugging at http.client level (requests->urllib3->http.client)
       # you will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
       # the only thing missing will be the response.body which is not logged.
-      from http.client import HTTPConnection # for Python 3
-      from httplib import HTTPConnection # for Python 2, httplib is former name of http.client.
+      try: # for Python 3
+          from http.client import HTTPConnection
+      except ImportError:
+          from httplib import HTTPConnection
       HTTPConnection.debuglevel = 1
 
       logging.basicConfig() # you need to initialize logging, otherwise you will not see anything from requests

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -184,11 +184,12 @@ API Changes
       import requests
       import logging
 
-      # these two lines enable debugging at httplib level (requests->urllib3->httplib)
+      # these two lines enable debugging at http.client level (requests->urllib3->http.client)
       # you will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
       # the only thing missing will be the response.body which is not logged.
-      import httplib
-      httplib.HTTPConnection.debuglevel = 1
+      from http.client import HTTPConnection # for Python 3
+      from httplib import HTTPConnection # for Python 2, httplib is former name of http.client.
+      HTTPConnection.debuglevel = 1
 
       logging.basicConfig() # you need to initialize logging, otherwise you will not see anything from requests
       logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
`httplib` was renamed in Python 3.