### PR TITLE
Remove int type on HTTPAdapter's max_retries argument doc

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -65,7 +65,7 @@ class HTTPAdapter(BaseAdapter):
 
     :param pool_connections: The number of urllib3 connection pools to cache.
     :param pool_maxsize: The maximum number of connections to save in the pool.
-    :param int max_retries: The maximum number of retries each connection
+    :param max_retries: The maximum number of retries each connection
         should attempt. Note, this applies only to failed DNS lookups, socket
         connections and connection timeouts, never to requests where data has
         made it to the server. By default, Requests does not retry failed


### PR DESCRIPTION
The argument description says `max_retries` can be an int, or a `urllib3.util.Retry` object. However, the type declared in the doc restricts it to int only. Passing a Retry object causes a warning in PyCharm code inspection.

The behaviour described for `max_retries` is accurate: HTTPAdapter passes `max_retries` to `Retry.from_int()`, which just returns the input if `max_retries` is a Retry object.