### PR TITLE
Changes to support sending a complete response object when 407 errors…

### DIFF
--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -551,7 +551,9 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
             is_new_proxy_conn = self.proxy is not None and not getattr(conn, 'sock', None)
             if is_new_proxy_conn:
-                self._prepare_proxy(conn)
+                proxy_conn_response = self._prepare_proxy(conn)
+                if proxy_conn_response:
+                    return proxy_conn_response
 
             # Make the request on the httplib connection object.
             httplib_response = self._make_request(conn, method, url,
@@ -747,7 +749,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         else:
             set_tunnel(self.host, self.port, self.proxy_headers)
 
-        conn.connect()
+        return conn.connect()
 
     def _new_conn(self):
         """


### PR DESCRIPTION
… is found while doing the CONNECT to proxy. Added a way to stablish a connection using connect over an already connected socket

Trying to connect to a "https" web page using a proxy uses a "HTTP CONNECT" verb to tell the proxy that we want to connect to a https destination.
With "basic authentication" the "CONNECT" is sent with the appropriate headers so the proxy can authenticate the request and do the request to the https web server. (That headers are setup by the requests library)
With "NTLM" we use a plugin (requests-ntlm) that is set as a hook and it is called on every request response. For example: with HTTP, the requests library sends a "GET" to a web page, as a response we get a HTTP-407 that is handled by the plugin hook to do the NTLM negotiation and authentication
In a HTTPS scenario, the first connection to the proxy is being done with the "CONNECT". At that time, requests does not set any authentication header (because it is handled by a plugin) and we get an 407 authentication Error.

This Patch tries to avoid raising an exception on "Proxy Authentication" errors and it sends back a complete http response so it can be handled by the requests-ntlm plugin and reuse an already connected and authenticated socket to do the connection