### PR TITLE
Fix #3017: Whitespace characters surrounding a URL should be ignored

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -165,3 +165,4 @@ Patches and Suggestions
 - Robin Linderborg (`@vienno <https://github.com/vienno>`_)
 - Brian Samek (`@bsamek <https://github.com/bsamek>`_)
 - Dmitry Dygalo (`@Stranger6667 <https://github.com/Stranger6667>`_)
+- Tomáš Heger (`@geckon <https://github.com/geckon>`_)

--- a/requests/models.py
+++ b/requests/models.py
@@ -335,6 +335,9 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         else:
             url = unicode(url) if is_py2 else str(url)
 
+        # Ignore any leading and trailing whitespace characters.
+        url = url.strip()
+
         # Don't do any URL preparation for non-HTTP schemes like `mailto`,
         # `data` etc to work around exceptions from `url_parse`, which
         # handles RFC 3986 only.

--- a/test_requests.py
+++ b/test_requests.py
@@ -1317,6 +1317,17 @@ class TestCaseInsensitiveDict:
         cid['changed'] = True
         assert cid != cid_copy
 
+    def test_url_surrounding_whitespace(self, httpbin):
+        """Test case with URLs surrounded by whitespace characters."""
+        get_url = httpbin('get')
+        # All surrounding whitespaces are supposed to be ignored:
+        assert requests.get(get_url + ' ').status_code == 200
+        assert requests.get(' ' + get_url).status_code == 200
+        assert requests.get(get_url + ' \t ').status_code == 200
+        assert requests.get('  \t' + get_url).status_code == 200
+        assert requests.get(get_url + '\n').status_code == 200
+        # The whitespaces can't be in the middle of the URL though:
+        assert requests.get(get_url + ' abc').status_code == 404
 
 class TestUtils:
 


### PR DESCRIPTION
My attempt to fix [the issue I reported](https://github.com/kennethreitz/requests/issues/3017). Feel free to comment my changes, especially if you don't agree with them.