### PR TITLE
[MULTIPART-FILE] Content type should always be set

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -454,10 +454,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                         content_type = 'application/x-www-form-urlencoded'
 
             self.prepare_content_length(body)
-
-            # Add content-type if it wasn't explicitly provided.
-            if content_type and ('content-type' not in self.headers):
-                self.headers['Content-Type'] = content_type
+            self.headers['Content-Type'] = content_type
 
         self.body = body
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -445,6 +445,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             # Multi-part file uploads.
             if files:
                 (body, content_type) = self._encode_files(files, data)
+                self.headers['Content-Type'] = content_type
             else:
                 if data:
                     body = self._encode_params(data)
@@ -454,7 +455,9 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                         content_type = 'application/x-www-form-urlencoded'
 
             self.prepare_content_length(body)
-            self.headers['Content-Type'] = content_type
+            # Add content-type if it wasn't explicitly provided.
+            if content_type and ('content-type' not in self.headers):
+                self.headers['Content-Type'] = content_type
 
         self.body = body
 


### PR DESCRIPTION
# Context 

In here:

https://github.com/kennethreitz/requests/blob/v2.7.0/requests/models.py#L464-L466

The content type is only set if the there isn't one already set. I feel this shouldn't be the case.

As we can see here:  https://github.com/kennethreitz/requests/blob/master/requests/packages/urllib3/filepost.py#L92

The content type string has a boundary generated by this method. This is specific to the body being encoded. Without this boundary and content type, the data being posted is no longer considered `Multipart Form Data`, which is the whole point of specifying `files=` in the post method.

Even raising an exception would be better than silently skipping setting the content type.