### PR TITLE
Support non-ASCII Reason Phrase as per RFC2616

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -19,7 +19,7 @@ from .packages.urllib3.util.retry import Retry
 from .compat import urlparse, basestring
 from .utils import (DEFAULT_CA_BUNDLE_PATH, get_encoding_from_headers,
                     prepend_scheme_if_needed, get_auth_from_url, urldefragauth,
-                    select_proxy)
+                    select_proxy, get_rfc2047_text_as_unicode)
 from .structures import CaseInsensitiveDict
 from .packages.urllib3.exceptions import ClosedPoolError
 from .packages.urllib3.exceptions import ConnectTimeoutError
@@ -223,7 +223,11 @@ class HTTPAdapter(BaseAdapter):
         # Set encoding.
         response.encoding = get_encoding_from_headers(response.headers)
         response.raw = resp
-        response.reason = response.raw.reason
+
+        if isinstance(resp.reason, bytes):
+            response.reason = get_rfc2047_text_as_unicode(resp.reason)
+        else:
+            response.reason = resp.reason
 
         if isinstance(req.url, bytes):
             response.url = req.url.decode('utf-8')

--- a/requests/models.py
+++ b/requests/models.py
@@ -9,6 +9,7 @@ This module contains the primary objects that power Requests.
 
 import collections
 import datetime
+import codecs
 
 from io import BytesIO, UnsupportedOperation
 from .hooks import default_hooks
@@ -830,11 +831,16 @@ class Response(object):
 
         http_error_msg = ''
 
+        def encode(s):
+            return codecs.encode(s, 'unicode_escape')
+
         if 400 <= self.status_code < 500:
-            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '%s Client Error: %s for url: %s' % (
+                self.status_code, encode(self.reason), encode(self.url))
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '%s Server Error: %s for url: %s' % (
+                self.status_code, encode(self.reason), encode(self.url))
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -20,6 +20,7 @@ import sys
 import socket
 import struct
 import warnings
+import email.header  # For RFC2047 decoding.
 
 from . import __version__
 from . import certs
@@ -349,6 +350,21 @@ def get_encoding_from_headers(headers):
 
     if 'text' in content_type:
         return 'ISO-8859-1'
+
+
+def get_rfc2047_text_as_unicode(text):
+    """Returns unicode value of text encoded using RF2047 (MIME for Text)
+
+    RFC2616 specifies that header values and reason phrases are
+    encoded in this manner. RFC7230, which obsoletes RC2616,
+    recommends treating non-ASCII header values as 'opaque data'.
+    In the case of the reason phrase, we should try to decode it
+    due to its possible localization and intent for display to the user.
+
+    :params text: bytestring within ISO-8859-1/Latin1 or encoded with RC2047.
+    """
+    unmimed, encoding = email.header.decode_header(text)[0]
+    return unmimed.decode(encoding or 'ISO-8859-1')
 
 
 def stream_decode_response_unicode(iterator, r):


### PR DESCRIPTION
RFC2616 specifies that header values and reason phrases are encoded in in ISO-8859-1 or RFC2047 (MIME for text). RFC7230, which obsoletes RC2616, recommends treating non-ASCII header values as 'opaque data'.

In the case of the Reason Phrase, however, we should try to decode it as described due to its possible/encouraged localization and due to its purpose for display to the user; treating it as 'opaque data' is not useful and prevents its intended use.

Note that several production servers, including Apache Tomcat, send responses conforming to RFC2616. Servers that respond only in US-ASCII are unaffected by this change. This *only* regresses (by introducing possible encoding errors) for servers that send responses conforming to neither RFC, which I believe are either uncommon or non-existent.

Fixes kennethreitz/requests#3009