### PR TITLE
Allow for exceptions from tell()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Release History
 **Bugfixes**
 
 - Don't use redirect_cache if allow_redirects=False
+- When passed objects that throw exceptions from ``tell()``, send them via
+  chunked transfer encoding instead of failing.
 
 2.9.1 (2015-12-21)
 ++++++++++++++++++

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -83,7 +83,12 @@ def super_len(o):
                 )
 
     if hasattr(o, 'tell'):
-        current_position = o.tell()
+        try:
+            current_position = o.tell()
+        except (OSError, IOError):
+            # This can happen in some weird situations, such as when the file
+            # is actually a special file descriptor like stdin.
+            current_position = 0
 
     return max(0, total_length - current_position)
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -87,8 +87,10 @@ def super_len(o):
             current_position = o.tell()
         except (OSError, IOError):
             # This can happen in some weird situations, such as when the file
-            # is actually a special file descriptor like stdin.
-            current_position = 0
+            # is actually a special file descriptor like stdin. In this
+            # instance, we don't know what the length is, so set it to zero and
+            # let requests chunk it instead.
+            current_position = total_length
 
     return max(0, total_length - current_position)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,6 @@ from .compat import StringIO, cStringIO
 
 
 class TestSuperLen:
-
     @pytest.mark.parametrize(
         'stream, value', (
             (StringIO.StringIO, 'Test'),
@@ -32,6 +31,20 @@ class TestSuperLen:
         s = StringIO.StringIO()
         s.write('foobarbogus')
         assert super_len(s) == 0
+
+    @pytest.mark.parametrize('error', [IOError, OSError])
+    def test_super_len_handles_files_raising_weird_errors_in_tell(self, error):
+        """
+        If tell() raises errors, assume the cursor is at position zero.
+        """
+        class BoomFile(object):
+            def __len__(self):
+                return 5
+
+            def tell(self):
+                raise error()
+
+        assert super_len(BoomFile()) == 5
 
 
 class TestGetEnvironProxies:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ class TestSuperLen:
             def tell(self):
                 raise error()
 
-        assert super_len(BoomFile()) == 5
+        assert super_len(BoomFile()) == 0
 
 
 class TestGetEnvironProxies:


### PR DESCRIPTION
Resolves #3035.

I'm not actually sure that this approach is the right one: I'm inclined to say that, when an exception is hit from `tell()`, that we may want to assume we don't know the length at all (return length 0) and use chunked-transfer encoding. That's a particularly good idea in this case, as frequently stdin has an unknown length altogether.

Thoughts on that point @sigmavirus24 and @jkbrzt?