### PR TITLE
Fix autofunction Reference

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -104,7 +104,7 @@ Cookies
 Status Code Lookup
 ------------------
 
-.. autofunction:: requests.codes
+.. autoclass:: requests.codes
 
 ::
 


### PR DESCRIPTION
`requests.codes` is a class (`LookupDict`), not a function.