### PR TITLE
Fix api.rst References

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -63,7 +63,7 @@ from .status_codes import codes
 from .exceptions import (
     RequestException, Timeout, URLRequired,
     TooManyRedirects, HTTPError, ConnectionError,
-    FileModeWarning,
+    FileModeWarning, ConnectTimeout, ReadTimeout
 )
 
 # Set default logging handler to avoid "No handler found" warnings.


### PR DESCRIPTION
`api.rst` references `requests.ConnectTimeout` and `requests.ReadTimeout`, but they aren't imported into the top-level of the package.