### PR TITLE
Fix 'Transfer-Encoding: chunked' bug when upload an empty file

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -439,7 +439,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
             if length:
                 self.headers['Content-Length'] = builtin_str(length)
-            else:
+            elif 'Content-Length' not in self.headers:
                 self.headers['Transfer-Encoding'] = 'chunked'
         else:
             # Multi-part file uploads.


### PR DESCRIPTION
Though we have the `stdout` (which is also a `fileno` type with length=0) to care about, when we post or put a normal empty file, we still can not force to set the `Transfer-Encoding` to `chunked`.

I think it is clearly meaning that "I don't want to transfer the file in chunked type", when someone set the `Content-length=0` in headers. `requests` does too much in this case, and it will bring out some problem when requesting some servers which not support chunked type. The `Transfer-Encoding` parameter should be user's response to add into the headers.