### PR TITLE
Update docstring and API doc to document ability to add per-file headers in multipart POST

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -24,7 +24,11 @@ def request(method, url, **kwargs):
     :param json: (optional) json data to send in the body of the :class:`Request`.
     :param headers: (optional) Dictionary of HTTP Headers to send with the :class:`Request`.
     :param cookies: (optional) Dict or CookieJar object to send with the :class:`Request`.
-    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': ('filename', fileobj)}``) for multipart encoding upload.
+    :param files: (optional) Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.
+        ``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')``
+        or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content-type'`` is a string
+        defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers
+        to add for the file.
     :param auth: (optional) Auth tuple to enable Basic/Digest/Custom HTTP Auth.
     :param timeout: (optional) How long to wait for the server to send data
         before giving up, as a float, or a :ref:`(connect timeout, read

--- a/requests/models.py
+++ b/requests/models.py
@@ -103,8 +103,10 @@ class RequestEncodingMixin(object):
         """Build the body for a multipart/form-data request.
 
         Will successfully encode files when passed as a dict or a list of
-        2-tuples. Order is retained if data is a list of 2-tuples but arbitrary
+        tuples. Order is retained if data is a list of tuples but arbitrary
         if parameters are supplied as a dict.
+        The tuples may be 2-tuples (filename, fileobj), 3-tuples (filename, fileobj, contentype)
+        or 4-tuples (filename, fileobj, contentype, custom_headers).
 
         """
         if (not files):


### PR DESCRIPTION
I recently needed this function and could not find it in the docs - luckily SO pointed me at PR #1640.

However, I feel like this really should be documented, so here is my attempt.

Note:
* I have not run any tests whatsoever over this as this is "just a docs change" - I don't know if that's ok. 
* The API docs seem a bit inaccurate in that they do not mention that ``files`` can also be a list. Similarly the docsstring in ``_encode_files`` does not discuss the case where instead of a tuple a file-obj is provided.

