### PR TITLE
Add 421 Misdirected Request.

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -53,6 +53,7 @@ _codes = {
     416: ('requested_range_not_satisfiable', 'requested_range', 'range_not_satisfiable'),
     417: ('expectation_failed',),
     418: ('im_a_teapot', 'teapot', 'i_am_a_teapot'),
+    421: ('misdirected_request',),
     422: ('unprocessable_entity', 'unprocessable'),
     423: ('locked',),
     424: ('failed_dependency', 'dependency'),


### PR DESCRIPTION
The 421 Misdirect Request status code was originally added in [RFC 7540](https://tools.ietf.org/html/rfc7540#section-11.7), and is going to be actively used in [RFC 7838](https://www.rfc-editor.org/rfc/rfc7838.txt). This adds it to our status code registry.