### PR TITLE
Added a test to show a faulty behaviour when posting binary data for an object with no __iter__

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -465,9 +465,11 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
     def prepare_content_length(self, body):
         if hasattr(body, 'seek') and hasattr(body, 'tell'):
+            curr_pos = body.tell()
             body.seek(0, 2)
-            self.headers['Content-Length'] = builtin_str(body.tell())
-            body.seek(0, 0)
+            end_pos = body.tell()
+            self.headers['Content-Length'] = builtin_str(max(0, end_pos - curr_pos))
+            body.seek(curr_pos, 0)
         elif body is not None:
             l = super_len(body)
             if l:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -484,12 +484,9 @@ class TestRequests:
 
     def test_POSTBIN_SEEKED_OBJECT_WITH_NO_ITER(self, httpbin):
 
-        class BufferedStream(object):
+        class TestStream(object):
             def __init__(self, data):
-                if isinstance(data, buffer):
-                    self.data = data
-                else:
-                    self.data = buffer(data)
+                self.data = data.encode()
                 self.length = len(self.data)
                 self.index = 0
 
@@ -498,10 +495,10 @@ class TestRequests:
 
             def read(self, size=None):
                 if size:
-                    ret = buffer(self.data, self.index, size)
+                    ret = self.data[self.index:self.index + size]
                     self.index += size
                 else:
-                    ret = buffer(self.data, self.index)
+                    ret = self.data[self.index:]
                     self.index = self.length
                 return ret
 
@@ -516,12 +513,12 @@ class TestRequests:
                 elif where == 2:
                     self.index = self.length + offset
 
-        test = BufferedStream('test')
+        test = TestStream('test')
         post1 = requests.post(httpbin('post'), data=test)
         assert post1.status_code == 200
         assert post1.json()['data'] == 'test'
 
-        test = BufferedStream('test')
+        test = TestStream('test')
         test.seek(2)
         post2 = requests.post(httpbin('post'), data=test)
         assert post2.status_code == 200


### PR DESCRIPTION
An object with read / seek / tell but without \__iter__ triggers a code path in requests which causes the stream to seek to the start instead of the position it was when it was passed into the data of the request. The faulty code is in models.py in the function prepare_content_length where it seeks to the start of the stream.

The tests fail currently because this is a test to expose the bug.