### PR TITLE
Clear any pooled proxy connections

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -264,10 +264,12 @@ class HTTPAdapter(BaseAdapter):
     def close(self):
         """Disposes of any internal state.
 
-        Currently, this just closes the PoolManager, which closes pooled
-        connections.
+        Currently, this closes the PoolManager and any active ProxyManager,
+        which closes any pooled connections.
         """
         self.poolmanager.clear()
+        for proxy in self.proxy_manager.values():
+            proxy.clear()
 
     def request_url(self, request, proxies):
         """Obtain the url to use when making the final request.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Pygments==2.1.1
 pytest==2.8.7
 pytest-cov==2.2.1
 pytest-httpbin==0.2.0
+pytest-mock==0.11.0
 pytz==2015.7
 six==1.10.0
 snowballstemmer==1.2.1

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1188,6 +1188,17 @@ class TestRequests:
         next(r.iter_lines())
         assert len(list(r.iter_lines())) == 3
 
+    def test_session_close_proxy_clear(self, mocker):
+        proxies = {
+          'one': mocker.Mock(),
+          'two': mocker.Mock(),
+        }
+        session = requests.Session()
+        mocker.patch.dict(session.adapters['http://'].proxy_manager, proxies)
+        session.close()
+        proxies['one'].clear.assert_called_once_with()
+        proxies['two'].clear.assert_called_once_with()
+
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
Based on the explanation of the bug in #3090 this PR closes any pooled connections for any active ProxyManager object associated with the session.
