### PR TITLE
Change _store of CaseInsensitiveDict to OrderedDict

### DIFF
--- a/requests/structures.py
+++ b/requests/structures.py
@@ -10,6 +10,8 @@ Data structures that power Requests.
 
 import collections
 
+from .compat import OrderedDict
+
 
 class CaseInsensitiveDict(collections.MutableMapping):
     """
@@ -40,7 +42,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
 
     """
     def __init__(self, data=None, **kwargs):
-        self._store = collections.OrderedDict()
+        self._store = OrderedDict()
         if data is None:
             data = {}
         self.update(data, **kwargs)

--- a/requests/structures.py
+++ b/requests/structures.py
@@ -40,7 +40,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
 
     """
     def __init__(self, data=None, **kwargs):
-        self._store = dict()
+        self._store = collections.OrderedDict()
         if data is None:
             data = {}
         self.update(data, **kwargs)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -315,6 +315,26 @@ class TestRequests:
         prep = ses.prepare_request(req)
         assert 'Accept-Encoding' not in prep.headers
 
+    def test_headers_preserve_order(self, httpbin):
+        """Preserve order when headers provided as OrderedDict."""
+        ses = requests.Session()
+        ses.headers = collections.OrderedDict()
+        ses.headers['Accept-Encoding'] = 'identity'
+        ses.headers['First'] = '1'
+        ses.headers['Second'] = '2'
+        headers = collections.OrderedDict([('Third', '3'), ('Fourth', '4')])
+        headers['Fifth'] = '5'
+        headers['Second'] = '222'
+        req = requests.Request('GET', httpbin('get'), headers = headers)
+        prep = ses.prepare_request(req)
+        items = prep.headers.items()
+        assert items[0] == ('Accept-Encoding', 'identity')
+        assert items[1] == ('First', '1')
+        assert items[2] == ('Second', '222')
+        assert items[3] == ('Third', '3')
+        assert items[4] == ('Fourth', '4')
+        assert items[5] == ('Fifth', '5')
+
     @pytest.mark.parametrize('key', ('User-agent', 'user-agent'))
     def test_user_agent_transfers(self, httpbin, key):
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -325,9 +325,9 @@ class TestRequests:
         headers = OrderedDict([('Third', '3'), ('Fourth', '4')])
         headers['Fifth'] = '5'
         headers['Second'] = '222'
-        req = requests.Request('GET', httpbin('get'), headers = headers)
+        req = requests.Request('GET', httpbin('get'), headers=headers)
         prep = ses.prepare_request(req)
-        items = prep.headers.items()
+        items = list(prep.headers.items())
         assert items[0] == ('Accept-Encoding', 'identity')
         assert items[1] == ('First', '1')
         assert items[2] == ('Second', '222')

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -318,11 +318,11 @@ class TestRequests:
     def test_headers_preserve_order(self, httpbin):
         """Preserve order when headers provided as OrderedDict."""
         ses = requests.Session()
-        ses.headers = collections.OrderedDict()
+        ses.headers = OrderedDict()
         ses.headers['Accept-Encoding'] = 'identity'
         ses.headers['First'] = '1'
         ses.headers['Second'] = '2'
-        headers = collections.OrderedDict([('Third', '3'), ('Fourth', '4')])
+        headers = OrderedDict([('Third', '3'), ('Fourth', '4')])
         headers['Fifth'] = '5'
         headers['Second'] = '222'
         req = requests.Request('GET', httpbin('get'), headers = headers)


### PR DESCRIPTION
This will preserve order of request headers when passed to request method as `OrderedDict`.

Closes #3038.