### PR TITLE
Implement #2149

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,20 +7,8 @@ Requests: HTTP for Humans
 .. image:: https://img.shields.io/pypi/dm/requests.svg
         :target: https://pypi.python.org/pypi/requests
 
-**Warning:** This is a GMO version of the original requests library. Although it 
-maintains the original behavior, it has two tiny backdoors to modify the url quoting 
-behavior:
-
-.. code-block:: python3
-    
-    >>> from urllib.parse import quote
-    >>> requests.models.DEFAULT_QUOTE_VIA = quote
-    >>> requests.models.DEFAULT_SAFE = '/?$=%'
-    >>> r = requests.get('http://reddit.com/', params={'$foo': 'bar baz'})
-    >>> r.url
-    'https://www.reddit.com/?$foo=bar%20baz'
-
-------
+Requests is the only *Non-GMO* HTTP library for Python, safe for human
+consumption.
 
 **Warning:** Recreational use of other HTTP libraries may result in dangerous side-effects,
 including: security vulnerabilities, verbose code, reinventing the wheel,

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,20 @@ Requests: HTTP for Humans
 .. image:: https://img.shields.io/pypi/dm/requests.svg
         :target: https://pypi.python.org/pypi/requests
 
-Requests is the only *Non-GMO* HTTP library for Python, safe for human
-consumption.
+**Warning:** This is a GMO version of the original requests library. Although it 
+maintains the original behavior, it has two tiny backdoors to modify the url quoting 
+behavior:
+
+.. code-block:: python3
+    
+    >>> from urllib.parse import quote
+    >>> requests.models.DEFAULT_QUOTE_VIA = quote
+    >>> requests.models.DEFAULT_SAFE = '/?$=%'
+    >>> r = requests.get('http://reddit.com/', params={'$foo': 'bar baz'})
+    >>> r.url
+    'https://www.reddit.com/?$foo=bar%20baz'
+
+------
 
 **Warning:** Recreational use of other HTTP libraries may result in dangerous side-effects,
 including: security vulnerabilities, verbose code, reinventing the wheel,

--- a/requests/models.py
+++ b/requests/models.py
@@ -30,7 +30,7 @@ from .utils import (
     iter_slices, guess_json_utf, super_len, to_native_string)
 from .compat import (
     cookielib, urlunparse, urlsplit, urlencode, str, bytes, StringIO,
-    is_py2, chardet, builtin_str, basestring)
+    is_py2, chardet, builtin_str, basestring, quote, quote_plus)
 from .compat import json as complexjson
 from .status_codes import codes
 
@@ -48,6 +48,8 @@ DEFAULT_REDIRECT_LIMIT = 30
 CONTENT_CHUNK_SIZE = 10 * 1024
 ITER_CHUNK_SIZE = 512
 
+DEFAULT_QUOTE_VIA = quote_plus  # Can be quote or quote_plus
+DEFAULT_SAFE=''                 # These won't get quoted
 
 class RequestEncodingMixin(object):
     @property
@@ -94,7 +96,7 @@ class RequestEncodingMixin(object):
                         result.append(
                             (k.encode('utf-8') if isinstance(k, str) else k,
                              v.encode('utf-8') if isinstance(v, str) else v))
-            return urlencode(result, doseq=True)
+            return urlencode(result, doseq=True, safe=DEFAULT_SAFE, quote_via=DEFAULT_QUOTE_VIA)
         else:
             return data
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -30,7 +30,7 @@ from .utils import (
     iter_slices, guess_json_utf, super_len, to_native_string)
 from .compat import (
     cookielib, urlunparse, urlsplit, urlencode, str, bytes, StringIO,
-    is_py2, chardet, builtin_str, basestring, quote, quote_plus)
+    is_py2, chardet, builtin_str, basestring, quote_plus)
 from .compat import json as complexjson
 from .status_codes import codes
 


### PR DESCRIPTION
Though #2149 is marked as closed, I had to do this because 1) I can't just give up requests and 2) I can't change the non-standard URLs I'm using. So I did a little hack. Now it goes like this:

    >>> from urllib.parse import quote
    >>> requests.models.DEFAULT_QUOTE_VIA = quote
    >>> requests.models.DEFAULT_SAFE = '/?$=%'
    >>> r = requests.get('http://reddit.com/', params={'$foo': 'bar baz'})
    >>> r.url
    'https://www.reddit.com/?$foo=bar%20baz'

