### PR TITLE
Flip conditional in session.send()

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -557,7 +557,7 @@ class Session(SessionRedirectMixin):
 
         # It's possible that users might accidentally send a Request object.
         # Guard against that specific failure case.
-        if not isinstance(request, PreparedRequest):
+        if isinstance(request, Request):
             raise ValueError('You can only send PreparedRequests.')
 
         # Set up variables needed for resolve_redirects and dispatching of hooks

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -638,6 +638,14 @@ class TestRequests:
         resp = s.send(prep)
         assert resp.status_code == 200
 
+    def test_non_prepared_request_error(self):
+        s = requests.Session()
+        req = requests.Request(u('POST'), '/')
+
+        with pytest.raises(ValueError) as e:
+            s.send(req)
+        assert str(e.value) == 'You can only send PreparedRequests.'
+
     def test_custom_content_type(self, httpbin):
         r = requests.post(
             httpbin('post'),


### PR DESCRIPTION
Previously we checked that the `request` being sent was an instance of a
PreparedRequest. If a user somehow created a PreparedRequest using a different
Requests library instance, this check makes the request un-sendable.

(This happened recently - unbeknownst to me, my server was running an outdated
version of pip, vulnerable to this issue - pypa/pip#1489, which creates
multiple subdirectories (src/requests, src/requests/requests) when you rerun
pip install --target. So the PreparedRequest was being created in one version
of the library and compared against the other version of the library, and
throwing this exception, even though they were both PreparedRequest instances!)

It would probably be preferable to check the object's behavior (instead of
its type), but a PreparedRequest has a lot of behavior, and it wouldn't be
really feasible or allow us to provide a helpful error message to check all
of it here. Instead flip the conditional to guard against the user sending an
unprepared Request, which should still give us most of the benefits of the
better error message.

Fixes #3102