### PR TITLE
utils: let select_proxy not raise an exception when url has no hostname

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -579,7 +579,10 @@ def select_proxy(url, proxies):
     """
     proxies = proxies or {}
     urlparts = urlparse(url)
-    proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
+    if urlparts.hostname is None:
+        proxy = None
+    else:
+        proxy = proxies.get(urlparts.scheme+'://'+urlparts.hostname)
     if proxy is None:
         proxy = proxies.get(urlparts.scheme)
     return proxy

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -325,6 +325,7 @@ def test_dotted_netmask(mask, expected):
         ('hTTp://u:p@Some.Host/path', 'http://some.host.proxy'),
         ('hTTp://u:p@Other.Host/path', 'http://http.proxy'),
         ('hTTps://Other.Host', None),
+        ('file:///etc/motd', None),
     ))
 def test_select_proxies(url, expected):
     """Make sure we can select per-host proxies correctly."""


### PR DESCRIPTION
Fixes #3131.