### PR TITLE
docs: Add a note about SSL c_rehash

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -208,6 +208,9 @@ You can pass ``verify`` the path to a CA_BUNDLE file or directory with certifica
 
     >>> requests.get('https://github.com', verify='/path/to/certfile')
 
+.. note:: If ``verify`` is set to a path to a directory, the directory must have been processed using 
+  the c_rehash utility supplied with OpenSSL.
+
 This list of trusted CAs can also be specified through the ``REQUESTS_CA_BUNDLE`` environment variable.
 
 Requests can also ignore verifying the SSL certificate if you set ``verify`` to False.


### PR DESCRIPTION
Just adding a quick note to inform users that it's not enough to point to a directory with the certificates but the directory needs to be "indexed". It took me some time to figure this out ... this simple note might save time to others in the future :).