### PR TITLE
Refactor prepare_body

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -165,3 +165,4 @@ Patches and Suggestions
 - Brian Samek (`@bsamek <https://github.com/bsamek>`_)
 - Dmitry Dygalo (`@Stranger6667 <https://github.com/Stranger6667>`_)
 - piotrjurkiewicz
+- Casey Davidson (`@davidsoncasey <https://github.com/davidsoncasey>`_)

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -101,8 +101,8 @@ class RetryError(RequestException):
 class ConflictingHeaderError(RequestException):
     """Mutually exclusive request headers set"""
 
-class UnreachableCodeError(RequestException, RuntimeError):
-    """Unreachable code block reached"""
+class InvalidBodyError(RequestException, ValueError):
+    """An invalid request body was specified"""
 
 # Warnings
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -98,6 +98,9 @@ class StreamConsumedError(RequestException, TypeError):
 class RetryError(RequestException):
     """Custom retries logic failed"""
 
+class ConflictingHeaderError(RequestException):
+    """Mutually exclusive request headers set"""
+
 
 # Warnings
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -101,6 +101,8 @@ class RetryError(RequestException):
 class ConflictingHeaderError(RequestException):
     """Mutually exclusive request headers set"""
 
+class UnreachableCodeError(RequestException, RuntimeError):
+    """Unreachable code block reached"""
 
 # Warnings
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -470,6 +470,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 self.headers['Content-Length'] = builtin_str(length)
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
+            else:
+                assert False, "If body is not null, it must either have a length or be streamable"
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -23,11 +23,11 @@ from .packages.urllib3.exceptions import (
     DecodeError, ReadTimeoutError, ProtocolError, LocationParseError)
 from .exceptions import (
     HTTPError, MissingSchema, InvalidURL, ChunkedEncodingError,
-    ContentDecodingError, ConnectionError, StreamConsumedError)
+    ContentDecodingError, ConnectionError, StreamConsumedError, ConflictingHeaderError)
 from .utils import (
     guess_filename, get_auth_from_url, requote_uri,
     stream_decode_response_unicode, to_key_val_list, parse_header_links,
-    iter_slices, guess_json_utf, super_len, to_native_string)
+    iter_slices, guess_json_utf, super_len, to_native_string, determine_if_stream)
 from .compat import (
     cookielib, urlunparse, urlsplit, urlencode, str, bytes, StringIO,
     is_py2, chardet, builtin_str, basestring)
@@ -423,15 +423,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             content_type = 'application/json'
             body = complexjson.dumps(json)
 
-        is_stream = all([
-            hasattr(data, '__iter__'),
-            not isinstance(data, (basestring, list, tuple, dict))
-        ])
-
-        try:
-            length = super_len(data)
-        except (TypeError, AttributeError, UnsupportedOperation):
-            length = None
+        is_stream = determine_if_stream(data)
 
         if is_stream:
             body = data
@@ -439,10 +431,6 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             if files:
                 raise NotImplementedError('Streamed bodies and files are mutually exclusive.')
 
-            if length:
-                self.headers['Content-Length'] = builtin_str(length)
-            else:
-                self.headers['Transfer-Encoding'] = 'chunked'
         else:
             # Multi-part file uploads.
             if files:
@@ -455,27 +443,38 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                     else:
                         content_type = 'application/x-www-form-urlencoded'
 
-            self.prepare_content_length(body)
-
             # Add content-type if it wasn't explicitly provided.
             if content_type and ('content-type' not in self.headers):
                 self.headers['Content-Type'] = content_type
 
+        self.prepare_content_length(body)
         self.body = body
 
     def prepare_content_length(self, body):
-        if hasattr(body, 'seek') and hasattr(body, 'tell'):
-            curr_pos = body.tell()
-            body.seek(0, 2)
-            end_pos = body.tell()
-            self.headers['Content-Length'] = builtin_str(max(0, end_pos - curr_pos))
-            body.seek(curr_pos, 0)
-        elif body is not None:
-            l = super_len(body)
-            if l:
-                self.headers['Content-Length'] = builtin_str(l)
+        """Prepares Content-Length header.
+        
+        If the length of the body of the request can be computed, Content-Length is set using
+        super_len. If user has manually set either a Transfer-Encoding or Content-Length header
+        when it should not be set (they should be mutually exclusive) an ConflictingHeaderError
+        error will be raised.
+        """
+        if body is not None:
+            is_stream = determine_if_stream(body)
+
+            try:
+                length = super_len(body)
+            except (TypeError, AttributeError, UnsupportedOperation):
+                length = None
+
+            if length:
+                self.headers['Content-Length'] = builtin_str(length)
+            elif is_stream and not length:
+                self.headers['Transfer-Encoding'] = 'chunked'
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
+
+        if 'Transfer-Encoding' in self.headers and 'Content-Length' in self.headers:
+            raise ConflictingHeaderError('Transfer-Encoding and Content-Length headers both set')
 
     def prepare_auth(self, auth, url=''):
         """Prepares the given HTTP auth data."""

--- a/requests/models.py
+++ b/requests/models.py
@@ -471,7 +471,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
             else:
-                assert False, "If body is not null, it must either have a length or be streamable"
+                raise UnreachableCodeError("Non-null body must have length or be streamable")
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -471,7 +471,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
             else:
-                raise UnreachableCodeError("Non-null body must have length or be streamable")
+                raise InvalidBodyError("Non-null body must have length or be streamable")
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -731,6 +731,6 @@ def urldefragauth(url):
 def determine_if_stream(data):
     """Given data, determines if it should be sent as a stream.
     """
-    is_iterable = hasattr(data, '__iter__')
+    is_iterable = getattr(data, '__iter__', False)
     is_io_type = not isinstance(data, (basestring, list, tuple, dict))
     return is_iterable and is_io_type

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -726,3 +726,11 @@ def urldefragauth(url):
     netloc = netloc.rsplit('@', 1)[-1]
 
     return urlunparse((scheme, netloc, path, params, query, ''))
+
+
+def determine_if_stream(data):
+    """Given data, determines if it should be sent as a stream.
+    """
+    is_iterable = hasattr(data, '__iter__')
+    is_io_type = not isinstance(data, (basestring, list, tuple, dict))
+    return is_iterable and is_io_type

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1238,6 +1238,28 @@ class TestRequests:
         with pytest.raises(ValueError):
             r.json()
 
+    def test_empty_stream_with_auth_does_not_set_content_length_header(self, httpbin):
+        """Ensure that a byte stream with size 0 will not set both a Content-Length
+        and Transfer-Encoding header
+        """
+        auth = ('user', 'pass')
+        url = httpbin('post')
+        file_obj = io.BytesIO(b'')
+        r = requests.Request('POST', url, auth=auth, data=file_obj)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' in prepared_request.headers
+        assert 'Content-Length' not in prepared_request.headers
+
+    def test_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
+        """Ensure that a byte stream with size > 0 will not set both a Content-Length
+        and Transfer-Encoding header"""
+        auth = ('user', 'pass')
+        url = httpbin('post')
+        file_obj = io.BytesIO(b'test data')
+        r = requests.Request('POST', url, auth=auth, data=file_obj)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' not in prepared_request.headers
+        assert 'Content-Length' in prepared_request.headers
 
 class TestCaseInsensitiveDict:
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -21,8 +21,8 @@ from requests.compat import (
 from requests.cookies import cookiejar_from_dict, morsel_to_cookie
 from requests.exceptions import (
     ConnectionError, ConnectTimeout, InvalidSchema, InvalidURL,
-    MissingSchema, ReadTimeout, Timeout, RetryError, TooManyRedirects,
-    ProxyError)
+    MissingSchema, ReadTimeout, Timeout, RetryError, ConflictingHeaderError,
+    TooManyRedirects, ProxyError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin
@@ -1260,6 +1260,37 @@ class TestRequests:
         prepared_request = r.prepare()
         assert 'Transfer-Encoding' not in prepared_request.headers
         assert 'Content-Length' in prepared_request.headers
+
+    def test_chunked_upload_does_not_set_content_length_header(self, httpbin):
+        data = (i for i in [b'a', b'b', b'c'])
+        url = httpbin('post')
+        r = requests.Request('POST', url, data=data)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' in prepared_request.headers
+        assert 'Content-Length' not in prepared_request.headers
+
+    def test_chunked_upload_with_manually_set_content_length_header_raises_error(self, httpbin):
+        """Ensure that if a user manually sets a content length header when the data
+        is chunked that an ConflictingHeaderError is raised"""
+        data = (i for i in [b'a', b'b', b'c']) 
+        url = httpbin('post')
+        with pytest.raises(ConflictingHeaderError):
+            r = requests.post(url, data=data, headers={'Content-Length': 'foo'})
+
+    def test_content_length_with_manually_set_transfer_encoding_raises_error(self, httpbin):
+        """Ensure that if a user manually sets a Transfer-Encoding header when data is not chunked
+        that an ConflictingHeaderError is raised"""
+        data = 'test data'
+        url = httpbin('post')
+        with pytest.raises(ConflictingHeaderError):
+            r = requests.post(url, data=data, headers={'Transfer-Encoding': 'chunked'})
+
+    def test_null_body_does_not_raise_error(self, httpbin):
+        url = httpbin('post')
+        try:
+            requests.post(url, data=None)
+        except ConflictingHeaderError:
+            pytest.fail('ConflictingHeaderError raised')
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
@Lukasa Here's an alternative fix to #3066 (discussed in PR #3181), where I refactored `PreparedRequest.prepare_body` and `PreparedRequest.prepare_content_length` so that `prepare_content_length` is always called.

My only question is in the case when the body is a stream (which it is in the case that brought up this issue) that the current position will always be 0 when the length is calculated. Previously, in cases where `prepare_auth` was not called, the content length was being calculated with `super_len`, now it would be calculated using `self.headers['Content-Length'] = builtin_str(max(0, end_pos - curr_pos))`. As far as I can tell, this will give the same result (as long as the current position is 0), and this is how it's been computed in cases where authorization is being used. But I'm curious if you have thoughts about this.
