### PR TITLE
Replace tab with appropriate spaces.

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -444,7 +444,7 @@ class Session(SessionRedirectMixin):
         :param cert: (optional) if String, path to ssl client cert file (.pem).
             If Tuple, ('cert', 'key') pair.
         :rtype: requests.Response
-	"""
+        """
         # Create the Request.
         req = Request(
             method = method.upper(),


### PR DESCRIPTION
Looks like this crept in. It shouldn't break anything, it's in a multiline string, but still, let's get rid of it.