### PR TITLE
Allow graceful interruption of testserver.Server

### DIFF
--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -149,3 +149,14 @@ class TestTestServer:
 
         # if the server thread fails to finish, the test suite will hang
         # and get killed by the jenkins timeout.
+
+    def test_server_finishes_when_no_connections(self):
+        """the server thread exits even if there are no connections"""
+        server = Server.basic_response_server()
+        with server:
+            pass
+
+        assert len(server.handler_results) == 0
+
+        # if the server thread fails to finish, the test suite will hang
+        # and get killed by the jenkins timeout.

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -139,11 +139,9 @@ class TestTestServer:
     def test_server_finishes_on_error(self):
         """the server thread exits even if an exception exits the context manager"""
         server = Server.basic_response_server()
-        try:
+        with pytest.raises(Exception):
             with server:
                 raise Exception()
-        except Exception:
-            pass
 
         assert len(server.handler_results) == 0
 

--- a/tests/test_testserver.py
+++ b/tests/test_testserver.py
@@ -135,3 +135,17 @@ class TestTestServer:
             sock.close()
             
         assert server.handler_results[0] == data
+
+    def test_server_finishes_on_error(self):
+        """the server thread exits even if an exception exits the context manager"""
+        server = Server.basic_response_server()
+        try:
+            with server:
+                raise Exception()
+        except Exception:
+            pass
+
+        assert len(server.handler_results) == 0
+
+        # if the server thread fails to finish, the test suite will hang
+        # and get killed by the jenkins timeout.

--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -39,10 +39,6 @@ class Server(threading.Thread):
         self.ready_event = threading.Event()
         self.stop_event = threading.Event()
 
-        self.server_sock = self._create_socket_and_bind()
-        # in case self.port = 0
-        self.port = self.server_sock.getsockname()[1]
-
     @classmethod
     def text_response_server(cls, text, request_timeout=0.5, **kwargs):
         def text_response_handler(sock):
@@ -64,6 +60,9 @@ class Server(threading.Thread):
 
     def run(self):
         try:
+            self.server_sock = self._create_socket_and_bind()
+            # in case self.port = 0
+            self.port = self.server_sock.getsockname()[1]
             self.ready_event.set()
             self._handle_requests()
 
@@ -98,7 +97,7 @@ class Server(threading.Thread):
 
     def _accept_connection(self):
         try:
-            ready, _, _ = select.select([self.server_sock], [], [])
+            ready, _, _ = select.select([self.server_sock], [], [], self.WAIT_EVENT_TIMEOUT)
             if not ready:
                 return None
 

--- a/tests/testserver/server.py
+++ b/tests/testserver/server.py
@@ -115,12 +115,12 @@ class Server(threading.Thread):
         if exc_type is None:
             self.stop_event.wait(self.WAIT_EVENT_TIMEOUT)
         else:
-            self._close_server_sock_ignore_errors()
-
             if self.wait_to_close_event:
                 # avoid server from waiting for event timeouts
                 # if an exception is found in the main thread
                 self.wait_to_close_event.set()
 
+        # ensure server thread doesn't get stuck waiting for connections
+        self._close_server_sock_ignore_errors()
         self.join()
         return False # allow exceptions to propagate


### PR DESCRIPTION
So that failing tests don't cause the server thread to hang
indefinitely, waiting for connections that will never come.

Rationale for suppressing error/traceback from interrupted
_accept_connection in testserver.Server:
https://gist.github.com/brettdh/b6e741227b2297f19d2118077f14dfa5