### PR TITLE
Fix to check for Plain ip notations in no_proxy settings if not CIDR

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -539,6 +539,10 @@ def should_bypass_proxies(url):
                 if is_valid_cidr(proxy_ip):
                     if address_in_network(ip, proxy_ip):
                         return True
+                elif ip == proxy_ip:
+                    # If no_proxy ip was defined in plain IP notation instead of cidr notation &
+                    # matches the IP of the index
+                    return True
         else:
             for host in no_proxy:
                 if netloc.endswith(host) or netloc.split(':')[0].endswith(host):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,42 +131,6 @@ class TestGetEnvironProxies:
         assert get_environ_proxies(url) != {}
 
 
-class TestShouldBypassProxies:
-    """
-    Tests for should_bypass_proxies function
-    """
-
-    @pytest.mark.parametrize(
-        'url, expected', (
-                ('http://192.168.0.1:5000/', True),
-                ('http://192.168.0.1/', True),
-                ('http://172.16.1.1/', True),
-                ('http://172.16.1.1:5000/', True),
-                ('http://localhost.localdomain:5000/v1.0/', True),
-        ))
-    def test_should_bypass_proxies(self, url, expected, monkeypatch):
-        """
-        Test to check if proxy is bypassed
-        """
-        monkeypatch.setenv('no_proxy', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
-        monkeypatch.setenv('NO_PROXY', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
-        assert should_bypass_proxies(url) == expected
-
-    @pytest.mark.parametrize(
-        'url, expected', (
-                ('http://172.16.1.12/', False),
-                ('http://172.16.1.12:5000/', False),
-                ('http://google.com:5000/v1.0/', False),
-        ))
-    def test_should_bypass_proxies(self, url, expected, monkeypatch):
-        """
-        Test to check if proxy is not bypassed
-        """
-        monkeypatch.setenv('no_proxy', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
-        monkeypatch.setenv('NO_PROXY', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
-        assert should_bypass_proxies(url) == expected
-
-
 class TestIsIPv4Address:
 
     def test_valid(self):
@@ -464,3 +428,23 @@ def test_to_native_string(value, expected):
     ))
 def test_urldefragauth(url, expected):
     assert urldefragauth(url) == expected
+
+
+@pytest.mark.parametrize(
+    'url, expected', (
+            ('http://192.168.0.1:5000/', True),
+            ('http://192.168.0.1/', True),
+            ('http://172.16.1.1/', True),
+            ('http://172.16.1.1:5000/', True),
+            ('http://localhost.localdomain:5000/v1.0/', True),
+            ('http://172.16.1.12/', False),
+            ('http://172.16.1.12:5000/', False),
+            ('http://google.com:5000/v1.0/', False),
+    ))
+def test_should_bypass_proxies(url, expected, monkeypatch):
+    """
+    Tests for function should_bypass_proxies to check if proxy can be bypassed or not
+    """
+    monkeypatch.setenv('no_proxy', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
+    monkeypatch.setenv('NO_PROXY', '192.168.0.0/24,127.0.0.1,localhost.localdomain,172.16.1.1')
+    assert should_bypass_proxies(url) == expected


### PR DESCRIPTION
For ipv4 addresses no_proxy is not being honored. 

[This line ](https://github.com/kennethreitz/requests/blob/master/requests/utils.py#L539) checks for `cidr notation` but `plain ip` notation is not considered, due to which the request is always routed to proxy server. This results in error ReadTimeoutError

Sample `proxy` configuration

    no_proxy=192.168.1.1,192.168.1.3,*.example.com
    http_proxy=http://192.168.1.100:8080
    https_proxy=http://192.168.1.100:8080

>When request is made to `192.168.1.1`, the request should not be made to proxy server, without this fix it is being made to proxy server `192.168.1.100`