### PR TITLE
Issue #2645 - Change behavior of Response.ok

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -623,11 +623,7 @@ class Response(object):
 
     @property
     def ok(self):
-        try:
-            self.raise_for_status()
-        except HTTPError:
-            return False
-        return True
+        return self.status_code in codes.success
 
     @property
     def is_redirect(self):

--- a/requests/models.py
+++ b/requests/models.py
@@ -33,6 +33,7 @@ from .compat import (
     is_py2, chardet, builtin_str, basestring)
 from .compat import json as complexjson
 from .status_codes import codes
+from . import status_codes
 
 #: The set of HTTP status codes that indicate an automatically
 #: processable redirect.
@@ -623,7 +624,7 @@ class Response(object):
 
     @property
     def ok(self):
-        return self.status_code in codes.success
+        return self.status_code in status_codes.success
 
     @property
     def is_redirect(self):
@@ -634,7 +635,7 @@ class Response(object):
 
     @property
     def is_permanent_redirect(self):
-        """True if this Response one of the permanent versions of redirect"""
+        """True if this Response is one of the permanent versions of redirect"""
         return ('location' in self.headers and self.status_code in (codes.moved_permanently, codes.permanent_redirect))
 
     @property

--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -89,3 +89,18 @@ for code, titles in _codes.items():
         setattr(codes, title, code)
         if not title.startswith('\\'):
             setattr(codes, title.upper(), code)
+
+_success = {
+    200,
+    201,
+    202,
+    203,
+    204,
+    205,
+    206,
+    207,
+    208,
+    226,
+}
+
+setattr(codes, 'success', _success)

--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -90,7 +90,7 @@ for code, titles in _codes.items():
         if not title.startswith('\\'):
             setattr(codes, title.upper(), code)
 
-_success = {
+success = set([
     200,
     201,
     202,
@@ -101,6 +101,4 @@ _success = {
     207,
     208,
     226,
-}
-
-setattr(codes, 'success', _success)
+])

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -570,6 +570,14 @@ class TestRequests:
             pytest.raises(ValueError, "requests.post(url, data=u('[{\"some\": \"data\"}]'), files={'some': f})")
 
     def test_request_ok_set(self, httpbin):
+        r = requests.get(httpbin('status', '200'))
+        assert r.ok
+
+    def test_request_ok_304(self, httpbin):
+        r = requests.get(httpbin('status', '304'))
+        assert not r.ok
+
+    def test_request_ok_404(self, httpbin):
         r = requests.get(httpbin('status', '404'))
         assert not r.ok
 


### PR DESCRIPTION
As discussed on issue #2645, I added a success attribute to
requests.codes. Now, Response.ok checks if the response's status code
is listed on requests.codes.success.
