### PR TITLE
Make BaseAdapter describe the mandatory adapter interface

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -54,7 +54,8 @@ class BaseAdapter(object):
     def __init__(self):
         super(BaseAdapter, self).__init__()
 
-    def send(self):
+    def send(self, request, stream=False, timeout=None, verify=True,
+             cert=None, proxies=None):
         raise NotImplementedError
 
     def close(self):

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -71,7 +71,7 @@ class BaseAdapter(object):
         raise NotImplementedError
 
     def close(self):
-       """Disposes of any internal state."""
+        """Disposes of any internal state."""
         raise NotImplementedError
 
 

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -71,7 +71,7 @@ class BaseAdapter(object):
         raise NotImplementedError
 
     def close(self):
-        """Disposes of any internal state."""
+        """Cleans up adapter specific items."""
         raise NotImplementedError
 
 

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -56,9 +56,22 @@ class BaseAdapter(object):
 
     def send(self, request, stream=False, timeout=None, verify=True,
              cert=None, proxies=None):
+        """Sends PreparedRequest object. Returns Response object.
+
+        :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
+        :param stream: (optional) Whether to stream the request content.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :type timeout: float or tuple
+        :param verify: (optional) Whether to verify SSL certificates.
+        :param cert: (optional) Any user-provided SSL certificate to be trusted.
+        :param proxies: (optional) The proxies dictionary to apply to the request.
+        """
         raise NotImplementedError
 
     def close(self):
+       """Disposes of any internal state."""
         raise NotImplementedError
 
 


### PR DESCRIPTION
BaseAdapter should document the mandatory interfaces for implementing your own adapter from scratch for a different HTTP library. Currently requests requires all the parameters from HTTPAdapter implementation of send to be defined so copying them and relevant documentation over to the base adapter. Also adding relevant parts of documentation on what close is to the base class