### PR TITLE
Use xfail marker for a test expected to fail without Internet connection

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1107,6 +1107,7 @@ class TestRequests:
             preq = req.prepare()
             assert test_url == preq.url
 
+    @pytest.mark.xfail(raises=ConnectionError)
     def test_auth_is_stripped_on_redirect_off_host(self, httpbin):
         r = requests.get(
             httpbin('redirect-to'),


### PR DESCRIPTION
This is only a minor improvement on the great work of https://github.com/kennethreitz/requests/pull/2859 that permits to run tests on hosts without Internet connection without failures.