### PR TITLE
Do not attempt to decode to unicode twice

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -665,7 +665,7 @@ class Response(object):
             # Special case for urllib3.
             if hasattr(self.raw, 'stream'):
                 try:
-                    for chunk in self.raw.stream(chunk_size, decode_content=True):
+                    for chunk in self.raw.stream(chunk_size, decode_content=False):
                         yield chunk
                 except ProtocolError as e:
                     raise ChunkedEncodingError(e)


### PR DESCRIPTION
It's possible I'm missing something here, but it seems like we should not be trying to decode via the underlying urllib3 method since `iter_content` is responsible for the decision of whether or not to decode.