### PR TITLE
Allow sending an unprepared request via session.

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -471,23 +471,14 @@ class Session(SessionRedirectMixin):
             cookies = cookies,
             hooks = hooks,
         )
-        prep = self.prepare_request(req)
 
-        proxies = proxies or {}
-
-        settings = self.merge_environment_settings(
-            prep.url, proxies, stream, verify, cert
-        )
-
-        # Send the request.
-        send_kwargs = {
-            'timeout': timeout,
-            'allow_redirects': allow_redirects,
-        }
-        send_kwargs.update(settings)
-        resp = self.send(prep, **send_kwargs)
-
-        return resp
+        return self.send_request(req,
+            proxies = proxies,
+            timeout = timeout,
+            allow_redirects = allow_redirects,
+            stream = stream,
+            verify = verify,
+            cert = cert)
 
     def get(self, url, **kwargs):
         """Sends a GET request. Returns :class:`Response` object.
@@ -558,6 +549,44 @@ class Session(SessionRedirectMixin):
         """
 
         return self.request('DELETE', url, **kwargs)
+
+    def send_request(self, req,
+        proxies=None,
+        timeout=None,
+        allow_redirects=True,
+        stream=None,
+        verify=None,
+        cert=None):
+        """Sends a :class:`Request <Request>` that a user has prepared.
+
+        :param request: the :class:`Request <Request>` to be sent.
+        :param proxies: (optional) Dictionary mapping protocol or protocol and
+            hostname to the URL of the proxy.
+        :param stream: (optional) whether to immediately download the response
+            content. Defaults to ``False``.
+        :param verify: (optional) whether the SSL cert will be verified.
+            A CA_BUNDLE path can also be provided. Defaults to ``True``.
+        :param cert: (optional) if String, path to ssl client cert file (.pem).
+            If Tuple, ('cert', 'key') pair.
+        :rtype: requests.Response
+        """
+        prep = self.prepare_request(req)
+
+        proxies = proxies or {}
+
+        settings = self.merge_environment_settings(
+            prep.url, proxies, stream, verify, cert
+        )
+
+        # Send the request.
+        send_kwargs = {
+            'timeout': timeout,
+            'allow_redirects': allow_redirects,
+        }
+        send_kwargs.update(settings)
+        resp = self.send(prep, **send_kwargs)
+
+        return resp
 
     def send(self, request, **kwargs):
         """Send a given PreparedRequest."""


### PR DESCRIPTION
This can be considered a request in the form of a PR because it was easier to make the code change than explain it. 

I have multiple places where i am passing around method, url, json etc before it makes it to the requests level. Now these can all be bundled up into a single request object which is much easier to pass around, but then i have to manually call

prep = session.prepare_request(req)
settings = session.merge_environment_settings(....) 
settings['timeout'] = timeout
session.send(prep, **settings)

Now it's not super hard, but it's something that happens by default doing request() and it's certainly not intuitive. If we add a send_request() which does exactly the same as request() just on an existing request object it makes it much easier to correctly use Request objects.

Note: If you like the idea but not the implementation and have something equivalent - please just do it your way. I don't care if this particular PR gets accepted or not if the idea gets up. I proposed this against 3.0 thinking it was going to be a more breaking change, but it seems pretty easy if you'd prefer i propose against master.

Thanks