### PR TITLE
added in type check for chunk_size

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -685,6 +685,8 @@ class Response(object):
 
         if self._content_consumed and isinstance(self._content, bool):
             raise StreamConsumedError()
+        elif not isinstance(chunk_size, int):
+            raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
         # simulate reading small chunks of the content
         reused_chunks = iter_slices(self._content, chunk_size)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -980,6 +980,20 @@ class TestRequests:
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
+    def test_response_chunk_size_int(self):
+        """Ensure that chunk_size is passed as an integer, otherwise
+        raise a TypeError.
+        """
+        r = requests.Response()
+        r.raw = io.BytesIO(b'the content')
+        chunks = r.iter_content(1)
+        assert all(len(chunk) == 1 for chunk in chunks)
+
+        r = requests.Response()
+        r.raw = io.BytesIO(b'the content')
+        with pytest.raises(TypeError):
+            chunks = r.iter_content("1024")
+
     def test_request_and_response_are_pickleable(self, httpbin):
         r = requests.get(httpbin('get'))
 


### PR DESCRIPTION
This should raise a type error if a non-integer chunk_size is passed. I'm assuming we're not concerned about a chunk_size of type long, but that may be wrong.