### PR TITLE
Allow None value for chunk_size again

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -685,7 +685,7 @@ class Response(object):
 
         if self._content_consumed and isinstance(self._content, bool):
             raise StreamConsumedError()
-        elif not isinstance(chunk_size, int):
+        elif chunk_size is not None and not isinstance(chunk_size, int):
             raise TypeError("chunk_size must be an int, it is instead a %s." % type(chunk_size))
         # simulate reading small chunks of the content
         reused_chunks = iter_slices(self._content, chunk_size)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -987,14 +987,19 @@ class TestRequests:
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
-    def test_response_chunk_size_int(self):
-        """Ensure that chunk_size is passed as an integer, otherwise
+    def test_response_chunk_size_type(self):
+        """Ensure that chunk_size is passed as None or an integer, otherwise
         raise a TypeError.
         """
         r = requests.Response()
         r.raw = io.BytesIO(b'the content')
         chunks = r.iter_content(1)
         assert all(len(chunk) == 1 for chunk in chunks)
+
+        r = requests.Response()
+        r.raw = io.BytesIO(b'the content')
+        chunks = r.iter_content(None)
+        assert list(chunks) == [b'the content']
 
         r = requests.Response()
         r.raw = io.BytesIO(b'the content')


### PR DESCRIPTION
Passing in `chunk_size=None` used to be fine, but started raising a `TypeError` following the addition of the type check (#3365)