### PR TITLE
adding in slice_length fix and test for chunk_size=None

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -384,6 +384,8 @@ def stream_decode_response_unicode(iterator, r):
 def iter_slices(string, slice_length):
     """Iterate over slices of a string."""
     pos = 0
+    if slice_length is None or slice_length <= 0: 
+        slice_length = len(string)
     while pos < len(string):
         yield string[pos:pos + slice_length]
         pos += slice_length

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -378,10 +378,16 @@ def test_get_encoding_from_headers(value, expected):
         ('', 0),
         ('T', 1),
         ('Test', 4),
+        ('Cont', 0),
+        ('Other', -5),
+        ('Content', None),
     ))
 def test_iter_slices(value, length):
-    assert len(list(iter_slices(value, 1))) == length
-
+    if length is None or (length <= 0 and len(value) > 0):
+        # Reads all content at once
+        assert len(list(iter_slices(value, length))) == 1
+    else:
+        assert len(list(iter_slices(value, 1))) == length
 
 @pytest.mark.parametrize(
     'value, expected', (


### PR DESCRIPTION
This fixes the issue discussed in #3369 but may not be the best way. It adds a certain amount of additional complexity to iter_slices that may be better solved by using a try/except. If we throw an exception requiring an int for slice_length, we could pass `chunk_size or len(self._content)` [here](https://github.com/kennethreitz/requests/blob/master/requests/models.py#L691) and solve the issue that way as well.