### PR TITLE
updating iter_content docstring to match functionality

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -657,6 +657,12 @@ class Response(object):
         read into memory.  This is not necessarily the length of each item
         returned as decoding can take place.
 
+        chunk_size must be of type int or None. A value of None will
+        function differently depending on the value of `stream`.
+        stream=True will read data as it arrives in whatever size the
+        chunks are recieved. If stream=False, data is returned as
+        a single chunk.
+
         If decode_unicode is True, content will be decoded using the best
         available encoding based on the response.
         """


### PR DESCRIPTION
Sorry to be bombarding you guys with PRs. This one is pretty minor but explains what I would say was non-obvious behaviour of the function before PR #3368 and PR #3365.