### PR TITLE
Change exception and variable names so that tests will run.

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -33,14 +33,14 @@ from .packages.urllib3.exceptions import SSLError as _SSLError
 from .packages.urllib3.exceptions import ResponseError
 from .cookies import extract_cookies_to_jar
 from .exceptions import (ConnectionError, ConnectTimeout, ReadTimeout, SSLError,
-                         ProxyError, RetryError, InvalidSchema)
+                         ProxyError, RetryError, InvalidScheme)
 from .auth import _basic_auth_str
 
 try:
     from .packages.urllib3.contrib.socks import SOCKSProxyManager
 except ImportError:
     def SOCKSProxyManager(*args, **kwargs):
-        raise InvalidSchema("Missing dependencies for SOCKS support.")
+        raise InvalidScheme("Missing dependencies for SOCKS support.")
 
 DEFAULT_POOLBLOCK = False
 DEFAULT_POOLSIZE = 10

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -152,7 +152,7 @@ class SessionRedirectMixin(object):
             if response.is_permanent_redirect and request.url != prepared_request.url:
                 self.redirect_cache[request.url] = prepared_request.url
 
-            self.rebuild_method(prepared_request, resp)
+            self.rebuild_method(prepared_request, response)
 
             # https://github.com/kennethreitz/requests/issues/1084
             if response.status_code not in (codes.temporary_redirect, codes.permanent_redirect):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -20,8 +20,8 @@ from requests.compat import (
     builtin_str, OrderedDict)
 from requests.cookies import cookiejar_from_dict, morsel_to_cookie
 from requests.exceptions import (
-    ConnectionError, ConnectTimeout, InvalidSchema, InvalidURL,
-    MissingSchema, ReadTimeout, Timeout, RetryError, TooManyRedirects,
+    ConnectionError, ConnectTimeout, InvalidScheme, InvalidURL,
+    MissingScheme, ReadTimeout, Timeout, RetryError, TooManyRedirects,
     ProxyError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
@@ -67,10 +67,10 @@ class TestRequests:
 
     @pytest.mark.parametrize(
         'exception, url', (
-            (MissingSchema, 'hiwpefhipowhefopw'),
-            (InvalidSchema, 'localhost:3128'),
-            (InvalidSchema, 'localhost.localdomain:3128/'),
-            (InvalidSchema, '10.122.1.1:3128/'),
+            (MissingScheme, 'hiwpefhipowhefopw'),
+            (InvalidScheme, 'localhost:3128'),
+            (InvalidScheme, 'localhost.localdomain:3128/'),
+            (InvalidScheme, '10.122.1.1:3128/'),
             (InvalidURL, 'http://'),
         ))
     def test_invalid_url(self, exception, url):


### PR DESCRIPTION
@Lukasa @sigmavirus24 

I tried running the tests on the proposed/3.0.0 branch, and found that they did not run. So I changed a couple of variable names to fix the obvious errors. If you prefer InvalidSchema and MissingSchema I can change those back, I changed the imports to match the names of the exceptions as they were defined.

After these changes, there is still one failing test. I'll try to take a look and see if I can debug it. But this was low hanging fruit.