### PR TITLE
Support responses like `HTTP/1.1 404 öööööööö`

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -849,12 +849,16 @@ class Response(object):
         """Raises stored :class:`HTTPError`, if one occurred."""
 
         http_error_msg = ''
+        if isinstance(self.reason, bytes):
+            reason = self.reason.decode('utf-8', 'ignore')
+        else:
+            reason = self.reason
 
         if 400 <= self.status_code < 500:
-            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = u'%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -987,6 +987,15 @@ class TestRequests:
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
+    def test_response_reason_unicode(self):
+        # check for unicode HTTP status
+        r = requests.Response()
+        r.url = u'unicode URL'
+        r.reason = u'Komponenttia ei löydy'.encode('utf-8')
+        r.status_code = 404
+        r.encoding = None
+        assert not r.ok # old behaviour - crashes here
+
     def test_response_chunk_size_type(self):
         """Ensure that chunk_size is passed as None or an integer, otherwise
         raise a TypeError.


### PR DESCRIPTION
Currently this code raises UnicodeDecodeError:

`requests.get('http://www.voice.fi//lampaan-kiveksia-ja-coca-cola-hulluutta-5-asiaa-joita-et-tiennyt-islannista-122015?utm_source=feed&utm_medium=feed&utm_content=article_link&utm_campaign=feed').ok`

Here is their status:
`HTTP/1.1 404 Komponenttia ei löydy`

This pull request allow module to handle URLs like this correctly