### PR TITLE
fixing #3366 for non-str header values

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -748,8 +748,10 @@ def check_header_validity(header):
 
     if isinstance(value, bytes):
         pat = _CLEAN_HEADER_REGEX_BYTE
-    else:
+    elif isinstance(value, str):
         pat = _CLEAN_HEADER_REGEX_STR
+    else:
+        return 
     if not pat.match(value):
         raise InvalidHeader("Invalid return character or leading space in header: %s" % name)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1145,9 +1145,10 @@ class TestRequests:
     def test_header_validation(self,httpbin):
         """Ensure prepare_headers regex isn't flagging valid header contents."""
         headers_ok = {'foo': 'bar baz qux',
-                      'bar': '1',
+                      'bar': u'fbbq'.encode('utf8'),
                       'baz': '',
-                      'qux': str.encode(u'fbbq')}
+                      'qux': 3,
+                      'f': '1'}
         r = requests.get(httpbin('get'), headers=headers_ok)
         assert r.request.headers['foo'] == headers_ok['foo']
 


### PR DESCRIPTION
This will fix issue #3386 with non-string/buffer header values, but there may be some more discussion to be had here. This is a passthrough for non-string/buffers which means all other datatypes will skip the regex check. I wasn't able to create the header split issue with most of the other standard datatypes I checked (lists, sets, dicts), so this *should* be safe with the passthrough. 

I think an alternative, and possibly better solution is to cast everything that isn't a byte string as a `str`, whether that be standard, or `encode('latin-1')`. This will ensure the check still runs and doesn't modify the value in the actual `Requests.headers` value. This is probably closer to what @sigmavirus24 already did [here](https://github.com/kennethreitz/requests/pull/866/files#diff-5956087d5835a57d9ef6fff974f6fd9bR273).