### PR TITLE
updating documentation to reflect decision of #3386

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -258,6 +258,10 @@ Behavioural Changes
 
 * Keys in the ``headers`` dictionary are now native strings on all Python
   versions, i.e. bytestrings on Python 2 and unicode on Python 3. If the
-  keys are not native strings (unicode on Python2 or bytestrings on Python 3)
+  keys are not native strings (unicode on Python 2 or bytestrings on Python 3)
   they will be converted to the native string type assuming UTF-8 encoding.
 
+* Values in the ``headers`` dictionary should always be strings. This has
+  been the project's position since before 1.0 but a recent change
+  (since version 2.11.0) enforces this more strictly. It's advised to avoid
+  passing header values as unicode when possible.

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -211,6 +211,7 @@ Note: Custom headers are given less precedence than more specific sources of inf
 
 Furthermore, Requests does not change its behavior at all based on which custom headers are specified. The headers are simply passed on into the final request.
 
+Note: All header values must be a ``string``, bytestring, or unicode. While permitted, it's advised to avoid passing unicode header values.
 
 More complicated POST requests
 ------------------------------


### PR DESCRIPTION
These are a couple of minor doc tweaks to document the decision to enforce strings in header values. Since requests previously operated with non-string header values, I figured it was best to make note that an exception will now be thrown in the event of a non-string value.

There may be some formatting and wording changes needed, this iteration is mainly to get the conversation going.