### PR TITLE
Remove duplicate import warnings

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -83,7 +83,5 @@ except ImportError:
 
 logging.getLogger(__name__).addHandler(NullHandler())
 
-import warnings
-
 # FileModeWarnings go off per the default.
 warnings.simplefilter('default', FileModeWarning, append=True)


### PR DESCRIPTION
Just reading through the source and found this dupe import - is it intentional? After running the tests locally before and after nothing fails... but there is some extra output as the test runs.

Before:
```
make test
# This runs all of the tests. To run an individual test, run py.test with
# the -k flag, like "py.test -k test_path_is_not_double_encoded"
py.test tests
======================================= test session starts =======================================
platform darwin -- Python 2.7.11, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /Users/harrisonjackson/Zapier/requests, inifile:
plugins: cov-2.2.1, httpbin-0.2.0, mock-0.11.0
collected 357 items

tests/test_hooks.py ...
tests/test_lowlevel.py .........
tests/test_requests.py ................................................................................................................................X.........127.0.0.1 - - [14/Jul/2016 09:42:31] "GET /stream/4 HTTP/1.1" 200 1080
X...................................................
tests/test_structures.py ....................
tests/test_testserver.py ...........
tests/test_utils.py ............................................................................................................................

============================= 355 passed, 2 xpassed in 42.56 seconds ==============================
```


After:
```
make test
# This runs all of the tests. To run an individual test, run py.test with
# the -k flag, like "py.test -k test_path_is_not_double_encoded"
py.test tests
======================================= test session starts =======================================
platform darwin -- Python 2.7.11, pytest-2.8.7, py-1.4.31, pluggy-0.3.1
rootdir: /Users/harrisonjackson/Zapier/requests, inifile:
plugins: cov-2.2.1, httpbin-0.2.0, mock-0.11.0
collected 357 items

tests/test_hooks.py ...
tests/test_lowlevel.py .........
tests/test_requests.py ...................127.0.0.1 - - [14/Jul/2016 09:44:19] "GET /get HTTP/1.1" 200 197
................................................127.0.0.1 - - [14/Jul/2016 09:44:21] "GET /gzip HTTP/1.1" 200 205
...127.0.0.1 - - [14/Jul/2016 09:44:21] "GET /get?f%C3%B8%C3%B8=f%C3%B8%C3%B8 HTTP/1.1" 200 370
..........................................................X.........127.0.0.1 - - [14/Jul/2016 09:44:21] "GET /stream/4 HTTP/1.1" 200 1080
X...................................................
tests/test_structures.py ....................
tests/test_testserver.py ...........
tests/test_utils.py ............................................................................................................................

============================= 355 passed, 2 xpassed in 41.34 seconds ==============================
```