### PR TITLE
removing redundant test

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -221,10 +221,6 @@ class TestRequests:
         assert r.history[0].status_code == 303
         assert r.history[0].is_redirect
 
-    # def test_HTTP_302_ALLOW_REDIRECT_POST(self):
-    #     r = requests.post(httpbin('status', '302'), data={'some': 'data'})
-    #     self.assertEqual(r.status_code, 200)
-
     def test_HTTP_200_OK_GET_WITH_PARAMS(self, httpbin):
         heads = {'User-agent': 'Mozilla/5.0'}
 


### PR DESCRIPTION
I was writing up a new test and found this comment block. Looks like it was commented out as part of a cleanup effort, but never removed. Test functionality is fulfilled by [this test](https://github.com/kennethreitz/requests/blob/master/tests/test_requests.py#L196).