### PR TITLE
raise InvalidHeader on multiple Location values

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -83,6 +83,10 @@ class InvalidURL(RequestException, ValueError):
     """ The URL provided was somehow invalid. """
 
 
+class InvalidHeader(RequestException, ValueError):
+    """The header value provided was somehow invalid."""
+
+
 class ChunkedEncodingError(RequestException):
     """The server declared chunked encoding but sent an invalid chunk."""
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -20,7 +20,8 @@ from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
 from .hooks import default_hooks, dispatch_hook
 from .utils import to_key_val_list, default_headers, to_native_string
 from .exceptions import (
-    TooManyRedirects, InvalidScheme, ChunkedEncodingError, ContentDecodingError)
+    TooManyRedirects, InvalidScheme, ChunkedEncodingError,
+    ContentDecodingError, InvalidHeader)
 from .packages.urllib3._collections import RecentlyUsedContainer
 from .structures import CaseInsensitiveDict
 
@@ -98,6 +99,10 @@ class SessionRedirectMixin(object):
         request = response.request
 
         while response.is_redirect:
+            if len(response.raw.headers.getlist('location')) > 1:
+                raise InvalidHeader('Response contains multiple Location headers. '
+                                    'Unable to perform redirect.')
+
             prepared_request = request.copy()
 
             if redirect_count > 0:

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -29,7 +29,7 @@ from .adapters import HTTPAdapter
 
 from .utils import (
     requote_uri, get_environ_proxies, get_netrc_auth, should_bypass_proxies,
-    get_auth_from_url
+    get_auth_from_url, is_valid_location
 )
 
 from .status_codes import codes
@@ -99,7 +99,7 @@ class SessionRedirectMixin(object):
         request = response.request
 
         while response.is_redirect:
-            if len(response.raw.headers.getlist('location')) > 1:
+            if not is_valid_location(response):
                 raise InvalidHeader('Response contains multiple Location headers. '
                                     'Unable to perform redirect.')
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -665,6 +665,17 @@ def parse_header_links(value):
 
     return links
 
+def is_valid_location(response):
+    """Verify that multiple Location headers weren't
+    returned from the last response.
+    """
+    headers = getattr(response.raw, 'headers', None)
+    if headers is not None:
+        getlist = getattr(headers, 'getlist', None)
+        if getlist is not None:
+            return len(getlist('location')) <= 1
+    # If response.raw isn't urllib3-like we can't reliably check this
+    return True  
 
 # Null bytes; no need to recreate these on each call to guess_json_utf
 _null = '\x00'.encode('ascii')  # encoding to ASCII for Python 3

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1626,7 +1626,7 @@ def test_requests_are_updated_each_time(httpbin):
     r0 = session.send(prep)
     assert r0.request.method == 'POST'
     assert session.calls[-1] == SendCall((r0.request,), {})
-    redirect_generator = session.resolve_redirects(r0, prep)
+    redirect_generator = session.resolve_redirects(r0)
     default_keyword_args = {
         'stream': False,
         'verify': True,


### PR DESCRIPTION
Addresses issue raised in #2939 with a fix for multiple Location headers in response. This currently breaks on `test_requests_are_updated_each_time` because the [`RedirectSession`](https://github.com/kennethreitz/requests/blob/proposed/3.0.0/tests/test_requests.py#L1564) populates it's `raw` attribute with `StringIO` rather than a urllib3 `HTTPResponse`. I can convert the `_build_raw` method to fix the test, if this looks like a workable solution.