### PR TITLE
converting hasattr usages to getattr

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -419,9 +419,7 @@ class HTTPAdapter(BaseAdapter):
 
             # Send the request.
             else:
-                if hasattr(conn, 'proxy_pool'):
-                    conn = conn.proxy_pool
-
+                conn = getattr(conn, 'proxy_pool', conn)
                 low_conn = conn._get_conn(timeout=DEFAULT_POOL_TIMEOUT)
 
                 try:

--- a/requests/auth.py
+++ b/requests/auth.py
@@ -78,7 +78,7 @@ class HTTPDigestAuth(AuthBase):
 
     def init_per_thread_state(self):
         # Ensure state is initialized just once per-thread
-        if not hasattr(self._thread_local, 'init'):
+        if not getattr(self._thread_local, 'init', None) is not None:
             self._thread_local.init = True
             self._thread_local.last_nonce = ''
             self._thread_local.nonce_count = 0

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -120,8 +120,7 @@ def extract_cookies_to_jar(jar, request, response):
     :param request: our own requests.Request object
     :param response: urllib3.HTTPResponse object
     """
-    if not (hasattr(response, '_original_response') and
-            response._original_response):
+    if not getattr(response, '_original_response', None):
         return
     # the _original_response field is the wrapped httplib.HTTPResponse object,
     req = MockRequest(request)
@@ -305,8 +304,11 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
         remove_cookie_by_name(self, name)
 
     def set_cookie(self, cookie, *args, **kwargs):
-        if hasattr(cookie.value, 'startswith') and cookie.value.startswith('"') and cookie.value.endswith('"'):
-            cookie.value = cookie.value.replace('\\"', '')
+        try:
+            if cookie.value.startswith('"') and cookie.value.endswith('"'):
+                cookie.value = cookie.value.replace('\\"', '')
+        except AttributeError:
+            pass
         return super(RequestsCookieJar, self).set_cookie(cookie, *args, **kwargs)
 
     def update(self, other):
@@ -373,10 +375,11 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
 def _copy_cookie_jar(jar):
     if jar is None:
         return None
-
-    if hasattr(jar, 'copy'):
+    
+    jarcopy = getattr(jar, 'copy', None)
+    if jarcopy is not None:
         # We're dealing with an instance of RequestsCookieJar
-        return jar.copy()
+        return jarcopy()
     # We're dealing with a generic CookieJar instance
     new_jar = copy.copy(jar)
     new_jar.clear()

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -21,9 +21,9 @@ class RequestException(IOError):
         response = kwargs.pop('response', None)
         self.response = response
         self.request = kwargs.pop('request', None)
-        if (response is not None and not self.request and
-                hasattr(response, 'request')):
-            self.request = self.response.request
+        response_request = getattr(self.response, 'request', None)
+        if response_request is not None and not self.request:
+            self.request = response_request
         super(RequestException, self).__init__(*args, **kwargs)
 
 

--- a/requests/hooks.py
+++ b/requests/hooks.py
@@ -25,7 +25,7 @@ def dispatch_hook(key, hooks, hook_data, **kwargs):
     hooks = hooks or dict()
     hooks = hooks.get(key)
     if hooks:
-        if hasattr(hooks, '__call__'):
+        if getattr(hooks, '__call__', None) is not None:
             hooks = [hooks]
         for hook in hooks:
             _hook_data = hook(hook_data, **kwargs)

--- a/requests/models.py
+++ b/requests/models.py
@@ -83,12 +83,13 @@ class RequestEncodingMixin(object):
 
         if isinstance(data, (str, bytes)):
             return data
-        elif hasattr(data, 'read'):
+        elif getattr(data, 'read', None) is not None:
             return data
-        elif hasattr(data, '__iter__'):
+        elif getattr(data, '__iter__', None) is not None:
             result = []
             for k, vs in to_key_val_list(data):
-                if isinstance(vs, basestring) or not hasattr(vs, '__iter__'):
+                is_iter = getattr(vs, '__iter__', None) is not None
+                if isinstance(vs, basestring) or not is_iter:
                     vs = [vs]
                 for v in vs:
                     if v is not None:
@@ -120,7 +121,8 @@ class RequestEncodingMixin(object):
         files = to_key_val_list(files or {})
 
         for field, val in fields:
-            if isinstance(val, basestring) or not hasattr(val, '__iter__'):
+            is_iter = getattr(val, '__iter__', None) is not None
+            if isinstance(val, basestring) or not is_iter:
                 val = [val]
             for v in val:
                 if v is not None:
@@ -170,7 +172,7 @@ class RequestHooksMixin(object):
 
         if isinstance(hook, collections.Callable):
             self.hooks[event].append(hook)
-        elif hasattr(hook, '__iter__'):
+        elif getattr(hook, '__iter__', None) is not None:
             self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
 
     def deregister_hook(self, event, hook):
@@ -432,7 +434,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 body = body.encode('utf-8')
 
         is_stream = all([
-            hasattr(data, '__iter__'),
+            getattr(data, '__iter__', None) is not None,
             not isinstance(data, (basestring, list, tuple, dict))
         ])
 
@@ -458,7 +460,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             else:
                 if data:
                     body = self._encode_params(data)
-                    if isinstance(data, basestring) or hasattr(data, 'read'):
+                    if isinstance(data, basestring) or getattr(data, 'read', None) is not None:
                         content_type = None
                     else:
                         content_type = 'application/x-www-form-urlencoded'
@@ -472,12 +474,14 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.body = body
 
     def prepare_content_length(self, body):
-        if hasattr(body, 'seek') and hasattr(body, 'tell'):
-            curr_pos = body.tell()
-            body.seek(0, 2)
-            end_pos = body.tell()
+        seek = getattr(body, 'seek', None)
+        tell = getattr(body, 'tell', None)
+        if seek is not None and tell is not None:
+            curr_pos = tell()
+            seek(0, 2)
+            end_pos = tell()
             self.headers['Content-Length'] = builtin_str(max(0, end_pos - curr_pos))
-            body.seek(curr_pos, 0)
+            seek(curr_pos, 0)
         elif body is not None:
             l = super_len(body)
             if l:
@@ -673,9 +677,10 @@ class Response(object):
 
         def generate():
             # Special case for urllib3.
-            if hasattr(self.raw, 'stream'):
+            raw_stream = getattr(self.raw, 'stream', None)
+            if raw_stream is not None:
                 try:
-                    for chunk in self.raw.stream(chunk_size, decode_content=True):
+                    for chunk in raw_stream(chunk_size, decode_content=True):
                         yield chunk
                 except ProtocolError as e:
                     raise ChunkedEncodingError(e)

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -38,9 +38,9 @@ DEFAULT_CA_BUNDLE_PATH = certs.where()
 
 def dict_to_sequence(d):
     """Returns an internal sequence dictionary update."""
-
-    if hasattr(d, 'items'):
-        d = d.items()
+    dict_items = getattr(d, 'items', None)
+    if dict_items is not None:
+        d = dict_items()
 
     return d
 
@@ -49,17 +49,17 @@ def super_len(o):
     total_length = 0
     current_position = 0
 
-    if hasattr(o, '__len__'):
+    if getattr(o, '__len__', None) is not None:
         total_length = len(o)
 
-    elif hasattr(o, 'len'):
+    elif getattr(o, 'len', None) is not None:
         total_length = o.len
 
-    elif hasattr(o, 'getvalue'):
+    elif getattr(o, 'getvalue', None) is not None:
         # e.g. BytesIO, cStringIO.StringIO
         total_length = len(o.getvalue())
 
-    elif hasattr(o, 'fileno'):
+    elif getattr(o, 'fileno', None) is not None:
         try:
             fileno = o.fileno()
         except io.UnsupportedOperation:
@@ -80,7 +80,7 @@ def super_len(o):
                     FileModeWarning
                 )
 
-    if hasattr(o, 'tell'):
+    if getattr(o, 'tell', None) is not None:
         try:
             current_position = o.tell()
         except (OSError, IOError):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -750,7 +750,7 @@ class TestRequests:
         s.proxies = getproxies()
         resp = s.send(prep)
 
-        assert hasattr(resp, 'hook_working')
+        assert getattr(resp, 'hook_working', None) is not None
 
     def test_prepared_from_session(self, httpbin):
         class DummyAuth(requests.auth.AuthBase):


### PR DESCRIPTION
This spawned off of [an article](https://hynek.me/articles/hasattr/) @Lukasa brought up in another PR. These changes should fix the pitfalls with using `hasattr` by converting their logic to use `getattr` instead.