### PR TITLE
removing incorrect param from resolve_redirects call

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1612,7 +1612,7 @@ def test_requests_are_updated_each_time(httpbin):
     r0 = session.send(prep)
     assert r0.request.method == 'POST'
     assert session.calls[-1] == SendCall((r0.request,), {})
-    redirect_generator = session.resolve_redirects(r0, prep)
+    redirect_generator = session.resolve_redirects(r0)
     default_keyword_args = {
         'stream': False,
         'verify': True,


### PR DESCRIPTION
This fixes the failing test I brought up [here](https://github.com/kennethreitz/requests/pull/3417#issuecomment-233136908). 4dfe7a4 removed the `req` param from `resolve_redirects` in favor of calling `response.request` in the method. The test wasn't updated though, so the request param is being assigned to `stream` which should be a boolean. This is causing the `test_requests_are_updated_each_time` test to fail.

Edit: Sorry, I overlooked that this was addressed in 4dfe7a4 but accidentally reverted in 18b26d2.