### PR TITLE
Adding better logging for requests/responses

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -8,6 +8,7 @@ This module provides a Session object to manage and persist settings across
 requests (cookies, auth, proxies).
 """
 import os
+import logging
 from collections import Mapping
 from datetime import datetime
 
@@ -27,7 +28,7 @@ from .adapters import HTTPAdapter
 
 from .utils import (
     requote_uri, get_environ_proxies, get_netrc_auth, should_bypass_proxies,
-    get_auth_from_url
+    get_auth_from_url, _log_transaction
 )
 
 from .status_codes import codes
@@ -36,6 +37,8 @@ from .status_codes import codes
 from .models import REDIRECT_STATI
 
 REDIRECT_CACHE_SIZE = 1000
+
+log = logging.getLogger(__name__)
 
 
 def merge_setting(request_setting, session_setting, dict_class=OrderedDict):
@@ -391,6 +394,7 @@ class Session(SessionRedirectMixin):
         )
         return p
 
+    @_log_transaction(log)
     def request(self, method, url,
         params=None,
         data=None,

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -12,11 +12,14 @@ import cgi
 import codecs
 import collections
 import io
+import logging
 import os
 import re
 import socket
+import six
 import struct
 import warnings
+from time import time
 
 from . import __version__
 from . import certs
@@ -33,6 +36,112 @@ _hush_pyflakes = (RequestsCookieJar,)
 NETRC_FILES = ('.netrc', '_netrc')
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
+
+
+def _log_transaction(log, level=logging.DEBUG):
+    """Logger for Response type objects!
+
+    Taken from:
+        https://github.com/openstack/opencafe
+    """
+
+    def _safe_decode(text, incoming='utf-8', errors='replace'):
+            """Decodes incoming text/bytes string using `incoming`
+               if they're not already unicode.
+            :param incoming: Text's current encoding
+            :param errors: Errors handling policy. See here for valid
+                values http://docs.python.org/2/library/codecs.html
+            :returns: text or a unicode `incoming` encoded
+                        representation of it.
+            """
+            if isinstance(text, six.text_type):
+                return text
+
+            return text.decode(incoming, errors)
+
+    """ Paramaterized decorator
+    Takes a python Logger object and an optional logging level.
+    """
+    def _decorator(func):
+        """Accepts a function and returns wrapped version of that function."""
+        def _wrapper(*args, **kwargs):
+            """Logging wrapper for any method that returns a requests response.
+            Logs requestslib response objects, and the args and kwargs
+            sent to the request() method, to the provided log at the provided
+            log level.
+            """
+            logline = '{0} {1}'.format(args, kwargs)
+
+            try:
+                log.debug(_safe_decode(logline))
+            except Exception as exception:
+                # Ignore all exceptions that happen in logging, then log them
+                log.info(
+                    'Exception occured while logging signature of calling'
+                    'method in http client')
+                log.exception(exception)
+
+            # Make the request and time it's execution
+            response = None
+            elapsed = None
+            try:
+                start = time()
+                response = func(*args, **kwargs)
+                elapsed = time() - start
+            except Exception as exception:
+                log.critical('Call to Requests failed due to exception')
+                log.exception(exception)
+                raise exception
+
+            # requests lib 1.0.0 renamed body to data in the request object
+            request_body = ''
+            if 'body' in dir(response.request):
+                request_body = response.request.body
+            elif 'data' in dir(response.request):
+                request_body = response.request.data
+            else:
+                log.info(
+                    "Unable to log request body, neither a 'data' nor a "
+                    "'body' object could be found")
+
+            # requests lib 1.0.4 removed params from response.request
+            request_params = ''
+            request_url = response.request.url
+            if 'params' in dir(response.request):
+                request_params = response.request.params
+            elif '?' in request_url:
+                request_url, request_params = request_url.split('?', 1)
+
+            logline = ''.join([
+                '\n{0}\nREQUEST SENT\n{0}\n'.format('-' * 12),
+                'request method..: {0}\n'.format(response.request.method),
+                'request url.....: {0}\n'.format(request_url),
+                'request params..: {0}\n'.format(request_params),
+                'request headers.: {0}\n'.format(response.request.headers),
+                'request body....: {0}\n'.format(request_body)])
+            try:
+                log.log(level, _safe_decode(logline))
+            except Exception as exception:
+                # Ignore all exceptions that happen in logging, then log them
+                log.log(level, '\n{0}\nREQUEST INFO\n{0}\n'.format('-' * 12))
+                log.exception(exception)
+
+            logline = ''.join([
+                '\n{0}\nRESPONSE RECEIVED\n{0}\n'.format('-' * 17),
+                'response status..: {0}\n'.format(response),
+                'response time....: {0}\n'.format(elapsed),
+                'response headers.: {0}\n'.format(response.headers),
+                'response body....: {0}\n'.format(response.content),
+                '-' * 79])
+            try:
+                log.log(level, _safe_decode(logline))
+            except Exception as exception:
+                # Ignore all exceptions that happen in logging, then log them
+                log.log(level, '\n{0}\nRESPONSE INFO\n{0}\n'.format('-' * 13))
+                log.exception(exception)
+            return response
+        return _wrapper
+    return _decorator
 
 
 def dict_to_sequence(d):


### PR DESCRIPTION
# Description
A logging mechanism to display important information regarding all requests and responses sent through the `requests` api.

# Why is this necessary?
At the company I work for we've been using this [logging mechanism](https://github.com/openstack/opencafe/blob/master/cafe/plugins/http/cafe/engine/http/client.py#L29) for a very long time and have had great success with it for testing numerous APIs. The level of logging provides the user with information they would normally have to dig for, and also provides a ready made log from which to draw relevant information. This is especially important for testing as it provides testers with sufficient logs to assess what is wrong, if a request should fail.

This information is even valuable for API developers as they can get immediate, easy to see, feedback on what their API is doing and returning.

# Try it for yourself!:
## Code:
```python
import logging;root=logging.getLogger();root.addHandler(logging.StreamHandler());root.setLevel(0);
import requests
requests.post('https://jsonplaceholder.typicode.com/posts', data="""{"id": 101, "title": "foo", "body": "bar", "userId": 1}""", headers={'content-type': 'application/json'})
```
## Logging output:
```
(<requests.sessions.Session object at 0x111000a90>,) {'data': '{"id": 101, "title": "foo", "body": "bar", "userId": 1}', 'url': 'https://jsonplaceholder.typicode.com/posts', 'method': 'post', 'headers': {'content-type': 'application/json'}, 'json': None}
Starting new HTTPS connection (1): jsonplaceholder.typicode.com
"POST /posts HTTP/1.1" 201 65

------------
REQUEST SENT
------------
request method..: POST
request url.....: https://jsonplaceholder.typicode.com/posts
request params..:
request headers.: {'Content-Length': '55', 'Connection': 'keep-alive', 'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'User-Agent': 'python-requests/2.10.0', 'content-type': 'application/json'}
request body....: {"id": 101, "title": "foo", "body": "bar", "userId": 1}


-----------------
RESPONSE RECEIVED
-----------------
response status..: <Response [201]>
response time....: 0.7399938106536865
response headers.: {'CF-RAY': '2c8d2175a6d20108-DFW', 'X-Content-Type-Options': 'nosniff', 'Etag': 'W/"41-1twMC34dpcMvmO2NLu+Kkg"', 'Pragma': 'no-cache', 'Server': 'cloudflare-nginx', 'Cache-Control': 'no-cache', 'Content-Type': 'application/json; charset=utf-8', 'Content-Length': '65', 'Set-Cookie': '__cfduid=dadf01d51aae9ede807ecf3e77439a3d51469591463; expires=Thu, 27-Jul-17 03:51:03 GMT; path=/; domain=.typicode.com; HttpOnly', 'X-Powered-By': 'Express', 'Via': '1.1 vegur', 'Vary': 'Origin, X-HTTP-Method-Override, Accept-Encoding', 'Date': 'Wed, 27 Jul 2016 03:51:03 GMT', 'Access-Control-Allow-Credentials': 'true', 'Expires': '-1', 'Connection': 'keep-alive'}
response body....: b'{\n  "id": 101,\n  "title": "foo",\n  "body": "bar",\n  "userId": 1\n}'
-------------------------------------------------------------------------------
```