### PR TITLE
Close and then release the connection

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -868,6 +868,6 @@ class Response(object):
         *Note: Should not normally need to be called explicitly.*
         """
         if not self._content_consumed:
-            return self.raw.close()
+            self.raw.close()
 
         return self.raw.release_conn()


### PR DESCRIPTION
urllib3 closes the underlying connection when we call
urllib3.Response.close but does not release it back to the connection
pool. This can cause issues when users have a blocking connection pool
configured and connections are not readily returned to the pool.

Since the underlying connection is closed, we should be able to safely
return the connection to the connection pool, so to fix this issue we
merely need to not return after closing the response.

Closes gh-3461