### PR TITLE
Fix python3.2 unicode literral error.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -853,10 +853,10 @@ class Response(object):
             reason = self.reason
 
         if 400 <= self.status_code < 500:
-            http_error_msg = u'%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
+            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, reason, self.url)
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = u'%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
+            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, reason, self.url)
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)


### PR DESCRIPTION
This is a specific fix for python3.2.
When I install requests version v2.11.0, I get an invalid syntax error.
It turns out the reason for that error is because "u" prefix for unicode strings are not allowed in python3.2. So I removed the "u" prefix to fix the issue.

To test it ,I moved the request library into my codebase and get syntax error:

https://travis-ci.org/huseyinyilmaz/placebo/builds/150770392

Than I fixed the issue and ran my tests again:

https://travis-ci.org/huseyinyilmaz/placebo/builds/150770803

I realized that this is not a right way to test this. But I could not install python3.2 on my mac. So I decided to use travis-ci's python version.
