### PR TITLE
Clarify Python versions supported by requests

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - Thread-safety
 
-Requests supports Python 2.6 — 3.5, and runs great on PyPy.
+Requests supports Python 2.6-2.7 and 3.3-3.5, and runs great on PyPy.
 
 
 The User Guide

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - Thread-safety
 
-Requests supports Python 2.6 — 2.7 and 3.3 — 3.5, and runs great on PyPy.
+Requests officially supports Python 2.6 — 2.7 and 3.3 — 3.5, and runs great on PyPy.
 
 
 The User Guide

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ Requests is ready for today's web.
 - Chunked Requests
 - Thread-safety
 
-Requests supports Python 2.6-2.7 and 3.3-3.5, and runs great on PyPy.
+Requests supports Python 2.6 — 2.7 and 3.3 — 3.5, and runs great on PyPy.
 
 
 The User Guide


### PR DESCRIPTION
Remove some confusion in the Python versions supported by Requests.