### PR TITLE
adding in pickling tests for PreparedRequest

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1053,6 +1053,43 @@ class TestRequests:
         assert r.request.url == pr.request.url
         assert r.request.headers == pr.request.headers
 
+    def test_prepared_request_is_pickleable(self):
+        p = requests.Request('GET', httpbin('get')).prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
+    def test_prepared_request_with_file_is_pickleable(self):
+        data = {'a': 0.0}
+        files = {'b': 'foo'}
+        r = requests.Request('POST', httpbin('post'), data=data, files=files)
+        p = r.prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
     def test_cannot_send_unprepared_requests(self, httpbin):
         r = requests.Request(url=httpbin())
         with pytest.raises(ValueError):

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1090,6 +1090,27 @@ class TestRequests:
 
         assert r.status_code == 200
 
+    def test_prepared_request_with_hook_is_pickleable(self):
+        def print_url(r, *args, **kwargs):
+            print(r.url)
+
+        r = requests.Request('POST', httpbin('post'), hooks=dict(response=print_url))
+        p = r.prepare()
+
+        # Verify we can pickle the request.
+        assert pickle.dumps(p)
+        r = pickle.dumps(p)
+
+        # Verify we can use the pickled request.
+        assert pickle.loads(r)
+        r = pickle.loads(r)
+
+        # Verify we can use the unpickled request.
+        s = requests.Session()
+        r = s.send(r)
+
+        assert r.status_code == 200
+
     def test_cannot_send_unprepared_requests(self, httpbin):
         r = requests.Request(url=httpbin())
         with pytest.raises(ValueError):


### PR DESCRIPTION
This is a continuation of @keyan's work in #2757 and addresses issue #1558 regarding pickling Request objects (specifically `PreparedRequest` objects in this PR).

These tests ensure that a standard `PreparedRequest`, a `PreparedRequest` with a file object as the body, and a `PreparedRequest` with hooks defined outside of the `locals` scope will all pickle properly.

This also works for data passed to the `json` parameter and I can add my test for that as well if it's deemed helpful.

Hooks defined inside of a method (such as in the [original test](https://github.com/kennethreitz/requests/pull/2757/files#diff-56c2d754173a4a158ce8f445834c8fe8R843) by @keyan) will fail because you can't pickle local objects. Is this a use case that needs to be handled?