### PR TITLE
updating HISTORY

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -30,7 +30,7 @@ Release History
 **Miscellaneous**
 
 - Updated bundled urllib3 to 1.16.
-- Some previous releases accidentally accepted integers as acceptable header values. This release does not.
+- Some previous releases accidentally accepted non-strings as acceptable header values. This release does not.
 
 2.10.0 (2016-04-29)
 +++++++++++++++++++


### PR DESCRIPTION
Clarifies that ALL non-string values are not permitted in headers.