### PR TITLE
#3490 removing Content-Type and Transfer-Encoding headers on redirect

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -140,9 +140,10 @@ class SessionRedirectMixin(object):
 
             # https://github.com/kennethreitz/requests/issues/1084
             if resp.status_code not in (codes.temporary_redirect, codes.permanent_redirect):
-                if 'Content-Length' in prepared_request.headers:
-                    del prepared_request.headers['Content-Length']
-
+                # https://github.com/kennethreitz/requests/issues/3490
+                purged_headers = ('Content-Length', 'Content-Type', 'Transfer-Encoding')
+                for header in purged_headers:
+                    prepared_request.headers.pop(header, None)
                 prepared_request.body = None
 
             headers = prepared_request.headers


### PR DESCRIPTION
This will remove additional headers (`Content-Type` and `Transfer-Encoding`) from non-temporary/non-permanent redirects in `resolve_redirects` to address #3490.

This functionality isn't currently being tested but I'm happy to add a test or two for it if desired.