### PR TITLE
Prevent environment variables from overridding Session settings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -167,3 +167,4 @@ Patches and Suggestions
 - piotrjurkiewicz
 - Jesse Shapiro <jesse@jesseshapiro.net> (`@haikuginger <https://github.com/haikuginger>`_)
 - Nate Prewitt <nate.prewitt@gmail.com> (`@nateprewitt <https://github.com/nateprewitt>`_)
+- Mike Pfister (`@pfista <https://github.com/pfista>`_)

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -634,6 +634,12 @@ class Session(SessionRedirectMixin):
 
         :rtype: dict
         """
+        # Merge all the kwargs.
+        proxies = merge_setting(proxies, self.proxies)
+        stream = merge_setting(stream, self.stream)
+        verify = merge_setting(verify, self.verify)
+        cert = merge_setting(cert, self.cert)
+
         # Gather clues from the surrounding environment.
         if self.trust_env:
             # Set environment's proxies.
@@ -646,12 +652,6 @@ class Session(SessionRedirectMixin):
             if verify is True or verify is None:
                 verify = (os.environ.get('REQUESTS_CA_BUNDLE') or
                           os.environ.get('CURL_CA_BUNDLE'))
-
-        # Merge all the kwargs.
-        proxies = merge_setting(proxies, self.proxies)
-        stream = merge_setting(stream, self.stream)
-        verify = merge_setting(verify, self.verify)
-        cert = merge_setting(cert, self.cert)
 
         return {'verify': verify, 'proxies': proxies, 'stream': stream,
                 'cert': cert}


### PR DESCRIPTION
In some cases, `Session` settings are overridden by environment settings. Session should inherit from its own settings before trying to pull in environment settings. 

For example, say environment variable `REQUESTS_CA_BUNDLE` is set to a certificate bundle, a session object is created and `session.verify = False`, and then that session is mounted to an adapter. If subsequent requests made do not explicitly pass in `verify=False`, certificate verification will be enabled despite having set `session.verify = False`. This is due to `merge_setting` defaulting to use the `request_setting` when merging verify, which is currently incorrectly set to the environment variables certificate file before checking `session.verify`.

This will ensure that `Request` object settings take precedence, then `Session` settings, then global environment settings.