### PR TITLE
adding passthrough in close() for non-urllib3-like Responses

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -870,4 +870,6 @@ class Response(object):
         if not self._content_consumed:
             self.raw.close()
 
-        return self.raw.release_conn()
+        release_conn = getattr(self.raw, 'release_conn', None)
+        if release_conn is not None:
+            release_conn()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1353,6 +1353,15 @@ class TestRequests:
         with pytest.raises(ValueError):
             r.json()
 
+    def test_response_without_release_conn(self):
+        """Test `close` call for non-urllib3-like raw objects.
+        Should work when `release_conn` attr doesn't exist on `response.raw`.
+        """
+        resp = requests.Response()
+        resp.raw = StringIO.StringIO('test')
+        assert not resp.raw.closed
+        resp.close()
+        assert resp.raw.closed
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
This is minor, but when testing `resolve_redirects` I encountered an `AttributeError` when passing a non-urllib3 Response. This is because the method unconditionally calls [`close`](https://github.com/kennethreitz/requests/blob/master/requests/models.py#L864) on the Response which in turn calls `release_conn` on the `Response.raw` attribute.

If the desire for requests is to maintain support for non-urllib3 objects in custom adapters, I think this would be a simple and useful addition. If urllib3 is going to be a de facto pattern for Responses though, this is probably just unnecessary code bloat.