### PR TITLE
Prepare for 2.11.1 bugfix release.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@
 Release History
 ---------------
 
+2.11.1 (2016-08-XX)
++++++++++++++++++++
+
+**Bugfixes**
+
+- Fixed a bug when using ``iter_content`` with ``decode_unicode=True`` for
+  streamed bodies would raise ``AttributeError``. This bug was introduced in
+  2.11.
+- Strip Content-Type and Transfer-Encoding headers from the header block when
+  following a redirect that transforms the verb from POST/PUT to GET.
+
 2.11.0 (2016-08-08)
 +++++++++++++++++++
 


### PR DESCRIPTION
@kennethreitz, this is all we need from a boring administrative perspective. If you merge this PR, you only need to do three things to release:

1. Update the version number to 2.11.1.
2. Put the date you do this in the changelog instead of the XX.
3. Push the release.

It'd be good to get this release out this week: it should put the nastiest bugs of 2.11 behind us and get people back to working again. =)