### PR TITLE
Fix incorrect encoding for reason

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -848,7 +848,7 @@ class Response(object):
 
         http_error_msg = ''
         if isinstance(self.reason, bytes):
-            reason = self.reason.decode('utf-8', 'ignore')
+            reason = self.reason.decode('latin1', 'ignore')
         else:
             reason = self.reason
 


### PR DESCRIPTION
HTTP status lines are latin1 and not utf-8

>    The TEXT rule is only used for descriptive field contents and values
   that are not intended to be interpreted by the message parser. Words
   of *TEXT MAY contain characters from character sets other than ISO-
   8859-1 only when encoded according to the rules of RFC 2047

To quote the RFC. Nobody implements RFC 2047 so this can be disregarded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kennethreitz/requests/3538)
<!-- Reviewable:end -->
