### PR TITLE
Specify self.cert is used for SSL client certificates

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -322,7 +322,7 @@ class Session(SessionRedirectMixin):
         #: SSL Verification default.
         self.verify = True
 
-        #: SSL certificate default.
+        #: SSL client certificate default.
         self.cert = None
 
         #: Maximum number of redirects allowed. If the request exceeds this


### PR DESCRIPTION
In addition to #3539 clarify that self.cert is used for SSL client certificates