### PR TITLE
removing redundant logic from prepare_content_length

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -90,6 +90,16 @@ class TestRequests:
         req = requests.Request(method, httpbin(method.lower())).prepare()
         assert 'Content-Length' not in req.headers
 
+    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS'))
+    def test_no_body_content_length(self, httpbin, method):
+        req = requests.Request(method, httpbin(method.lower())).prepare()
+        assert req.headers['Content-Length'] == '0'
+
+    @pytest.mark.parametrize('method', ('POST', 'PUT', 'PATCH', 'OPTIONS'))
+    def test_empty_content_length(self, httpbin, method):
+        req = requests.Request(method, httpbin(method.lower()), data='').prepare()
+        assert req.headers['Content-Length'] == '0'
+
     def test_override_content_length(self, httpbin):
         headers = {
             'Content-Length': 'not zero'


### PR DESCRIPTION
Background
========
So while working on #3535 I noticed that `prepare_content_length` will be fairly redundant after the patch is merged. I was going to push the abbreviated version of `prepare_content_length` into #3535 but found some inconsistencies in how we're currently handling Content-Length.

So here's a quick rundown of what I've found, and what it seems like *should* happen.

* #957 addressed #223 and added Content-Length to *everything*.
* #1142 amended this to NOT send Content-Length with GET/HEAD requests (Issue #1051)
* #2329 addressed the issue of not being able to override Content-Length with a custom header (Issue #2329)

From this, I'd expect:

* Content-Length to be set on all requests that are not using a HEAD/GET method.
* If a Content-Length header exists, that it remains untouched when sending a request.

Next Steps
=========

Currently, setting a body on a request will override the custom Content-Length header. The test implemented in #2329 doesn't test the code path with a body. I've added that test and the required logic to make it succeed. However, the solution attached here is not my preferred approach, rather the closest to the old functionality of prepare_content_length.

*Ideally*, I think that any call to `prepare_content_length` will do just that, set the Content-Length. That way if someone updates the body on a PreparedRequest, they can use `prepare_content_length` without having to delete a header, or recreate the object. This approach would require moving `if self.headers.get('Content-Length') is None` up to `prepare_body` and `prepare_auth` to run the overwrite check there.

This has the issue of causing latent errors though, if someone decides to use `prepare_content_length` elsewhere without the existence check. So if we're concerned about that being a possibility, then I think `prepare_content_length` should instead have an `overwrite` param which will bypass the [check](https://github.com/kennethreitz/requests/compare/master...nateprewitt:new_prepare_content_length#diff-afd5aad80649cdfae687bee05242c8faR472) to see if the header exists.


==========
This PR is two tangentially related fixes (abbreviating prepare_content_length post #3535 and fixing inconsistencies in how we handle Content-Lengths). This SHOULD NOT be merged and probably doesn't need to even be addressed until after #3535 is merged.