### PR TITLE
pysocks 1.5.7 blacklisting, due to IPv6 problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,6 @@ setup(
     tests_require=test_requirements,
     extras_require={
         'security': ['pyOpenSSL>=0.13', 'ndg-httpsclient', 'pyasn1'],
-        'socks': ['PySocks>=1.5.6'],
+        'socks': ['PySocks>=1.5.6, !=1.5.7'],
     },
 )


### PR DESCRIPTION
https://github.com/kennethreitz/requests/issues/3551