### PR TITLE
ISO-8859-1 fallback for reason decoding

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -848,6 +848,10 @@ class Response(object):
 
         http_error_msg = ''
         if isinstance(self.reason, bytes):
+            # We attempt to decode utf-8 first because some servers
+            # choose to localize their reason strings. If the string
+            # isn't utf-8, we fall back to iso-8859-1 for all other
+            # encodings. (See PR #3538)
             try:
                 reason = self.reason.decode('utf-8')
             except UnicodeDecodeError:

--- a/requests/models.py
+++ b/requests/models.py
@@ -848,7 +848,10 @@ class Response(object):
 
         http_error_msg = ''
         if isinstance(self.reason, bytes):
-            reason = self.reason.decode('utf-8', 'ignore')
+            try:
+                reason = self.reason.decode('utf-8')
+            except UnicodeDecodeError:
+                reason = self.reason.decode('iso-8859-1')
         else:
             reason = self.reason
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1022,6 +1022,18 @@ class TestRequests:
         r.encoding = None
         assert not r.ok  # old behaviour - crashes here
 
+    def test_response_reason_unicode_fallback(self):
+        # check raise_status falls back to ISO-8859-1
+        r = requests.Response()
+        r.url = 'some url'
+        reason = u'Komponenttia ei löydy'
+        r.reason = reason.encode('latin-1')
+        r.status_code = 500
+        r.encoding = None
+        with pytest.raises(requests.exceptions.HTTPError) as e:
+            r.raise_for_status()
+        assert reason in str(e)
+
     def test_response_chunk_size_type(self):
         """Ensure that chunk_size is passed as None or an integer, otherwise
         raise a TypeError.


### PR DESCRIPTION
This implements the proposed solution to #3538 by falling back from Unicode to ISO-8859-1 for raw reason decoding.

This is a relatively trivial fix, and I wasn't sure if you wanted to waste bandwidth fixing, @mitsuhiko. I had a brief chat with @Lukasa who said to toss this up, but I'll gladly drop it in favor of #3538, if you had plans to update.