### PR TITLE
Fix how we test fallback to latin-1 reason encoding

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1026,13 +1026,13 @@ class TestRequests:
         # check raise_status falls back to ISO-8859-1
         r = requests.Response()
         r.url = 'some url'
-        reason = u'Komponenttia ei löydy'
-        r.reason = reason.encode('latin-1')
+        reason = b'Komponenttia ei l\xf6ydy'
+        r.reason = reason
         r.status_code = 500
         r.encoding = None
         with pytest.raises(requests.exceptions.HTTPError) as e:
             r.raise_for_status()
-        assert reason in str(e)
+        assert reason.decode('latin-1') in str(e)
 
     def test_response_chunk_size_type(self):
         """Ensure that chunk_size is passed as None or an integer, otherwise


### PR DESCRIPTION
This was terribly broken and found while merging master into proposed/3.0.0