### PR TITLE
Swallow SSL errors raised by eventlet

### DIFF
--- a/requests/packages/urllib3/response.py
+++ b/requests/packages/urllib3/response.py
@@ -238,7 +238,7 @@ class HTTPResponse(io.IOBase):
 
             except BaseSSLError as e:
                 # FIXME: Is there a better way to differentiate between SSLErrors?
-                if 'read operation timed out' not in str(e):  # Defensive:
+                if 'timed out' not in str(e):  # Defensive:
                     # This shouldn't happen but just in case we're missing an edge
                     # case, let's avoid swallowing SSL errors.
                     raise


### PR DESCRIPTION
Fixes #3104 (or the weird mutant version of it that happens if you use eventlet).

When eventlet monkey-patches ssl, the resulting `socket.read` calls throw an instance of the same class (`SSLError`) with a different message (`'timed out'` instead of `'read operation timed out'`). This causes the SSLError to not get swallowed by urllib3 or requests.

Please let me know if you'd prefer the issue to be fixed in another way, happy to adjust--this was just the clearest place to fix it.