### PR TITLE
Streaming responses require encoding to be set

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -368,11 +368,6 @@ def get_encoding_from_headers(headers):
 def stream_decode_response_unicode(iterator, r):
     """Stream decodes a iterator."""
 
-    if r.encoding is None:
-        for item in iterator:
-            yield item
-        return
-
     decoder = codecs.getincrementaldecoder(r.encoding)(errors='replace')
     for chunk in iterator:
         rv = decoder.decode(chunk)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1042,6 +1042,22 @@ class TestRequests:
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
+        # raise an exception if encoding isn't set
+        r = requests.Response()
+        r.raw = io.BytesIO(b'the content')
+        r.encoding = None
+
+        with pytest.raises(TypeError):
+            chunks = r.iter_content(decode_unicode=True)
+
+        # raises an exception if the encoding is garbage
+        r = requests.Response()
+        r.raw = io.BytesIO(b'the content')
+        r.encoding = 'invalid encoding'
+
+        with pytest.raises(LookupError):
+            chunks = r.iter_content(decode_unicode=True)
+
     def test_response_reason_unicode(self):
         # check for unicode HTTP status
         r = requests.Response()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1039,23 +1039,22 @@ class TestRequests:
         r = requests.Response()
         r.raw = io.BytesIO(b'the content')
         r.encoding = 'ascii'
+
         chunks = r.iter_content(decode_unicode=True)
         assert all(isinstance(chunk, str) for chunk in chunks)
 
+    @pytest.mark.parametrize(
+        'encoding, exception', (
+            (None, TypeError),
+            ('invalid encoding', LookupError),
+        ))
+    def test_decode_unicode_encoding(self, encoding, exception):
         # raise an exception if encoding isn't set
         r = requests.Response()
         r.raw = io.BytesIO(b'the content')
-        r.encoding = None
+        r.encoding = encoding
 
-        with pytest.raises(TypeError):
-            chunks = r.iter_content(decode_unicode=True)
-
-        # raises an exception if the encoding is garbage
-        r = requests.Response()
-        r.raw = io.BytesIO(b'the content')
-        r.encoding = 'invalid encoding'
-
-        with pytest.raises(LookupError):
+        with pytest.raises(exception):
             chunks = r.iter_content(decode_unicode=True)
 
     def test_response_reason_unicode(self):


### PR DESCRIPTION
Resolves the issues called out in #3359 and #3481 when `Response.iter_content(decode_unicode=True)` would return bytes instead of unicode. This is a breaking change as it raises an exception if `Response.encoding` is not set before invoking this function.