### PR TITLE
Fix encoding issue in test_response_reason_unicode_fallback

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1026,13 +1026,13 @@ class TestRequests:
         # check raise_status falls back to ISO-8859-1
         r = requests.Response()
         r.url = 'some url'
-        reason = b'Komponenttia ei l\xf6ydy'
-        r.reason = reason
+        reason = u'Komponenttia ei löydy'
+        r.reason = reason.encode('latin-1')
         r.status_code = 500
         r.encoding = None
         with pytest.raises(requests.exceptions.HTTPError) as e:
             r.raise_for_status()
-        assert reason.decode('latin-1') in str(e)
+        assert reason in e.value.args[0]
 
     def test_response_chunk_size_type(self):
         """Ensure that chunk_size is passed as None or an integer, otherwise


### PR DESCRIPTION
`test_response_reason_unicode_fallback` is currently failing in Python 2. The original proposed fix in #3557 unfortunately didn't address the underlying issue.

While this patch should fix the test now, it may be worth taking a brief moment to discuss how we envision the original PR #3554 working. Currently an error retrieved from an `except` clause can't be cast as `str`, `unicode`, written to a file, or easily decoded in Python 2. It prints to the console fine, but that's about it. This seems like a semi-serious issue for making this exception usable. I need to run a few more tests this evening or tomorrow, so we can sit on this for the weekend unless someone has some obvious insight I'm missing.