### PR TITLE
Add workaround to avoid implicit import of encodings.idna. Fixes #3578.

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -10,6 +10,11 @@ This module contains the primary objects that power Requests.
 import collections
 import datetime
 
+# Import encoding now, to avoid implicit import later.
+# Implicit import within threads may cause LookupError when standard library is in a ZIP,
+# such as in Embedded Python. See https://github.com/kennethreitz/requests/issues/3578.
+import encodings.idna
+
 from io import BytesIO, UnsupportedOperation
 from .hooks import default_hooks
 from .structures import CaseInsensitiveDict


### PR DESCRIPTION
This is the workaround needed to avoid "LookupError: unknown encoding: idna" when Requests is used in a threaded context, and the Python standard library is inside a ZIP, such as the case of embedded distributions of Python.