### PR TITLE
Allow dicts for Session cookies

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -339,7 +339,7 @@ class Session(SessionRedirectMixin):
         #: session. By default it is a
         #: :class:`RequestsCookieJar <requests.cookies.RequestsCookieJar>`, but
         #: may be any other ``cookielib.CookieJar`` compatible object.
-        self.cookies = cookiejar_from_dict({})
+        self._cookies = cookiejar_from_dict({})
 
         # Default connection adapters.
         self.adapters = OrderedDict()
@@ -354,6 +354,20 @@ class Session(SessionRedirectMixin):
 
     def __exit__(self, *args):
         self.close()
+
+    @property
+    def cookies(self):
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, value):
+        """Set _cookies to CookieJar, if applicable. Otherwise, try to
+        create a new ``RequestsCookieJar`` by iterating value object.
+        """
+        if isinstance(value, cookielib.CookieJar):
+            self._cookies = value
+        else:
+            self._cookies = cookiejar_from_dict(value)
 
     def prepare_request(self, request):
         """Constructs a :class:`PreparedRequest <PreparedRequest>` for

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -944,6 +944,18 @@ class TestRequests:
         # make sure one can use items multiple times
         assert list(items) == list(items)
 
+    def test_cookie_as_dict_for_session(self, httpbin):
+        s = requests.Session()
+        s.cookies = {'some_cookie': 'some_value'}
+        assert isinstance(s.cookies, requests.cookies.RequestsCookieJar)
+        req = requests.Request('GET', httpbin('get'))
+        prep_req = s.prepare_request(req)
+        resp = s.send(prep_req)
+        cookies = {}
+        for c in resp.request._cookies:
+            cookies[c.name] = c.value
+        assert cookies['some_cookie'] == 'some_value'
+
     def test_cookie_duplicate_names_different_domains(self):
         key = 'some_cookie'
         value = 'some_value'


### PR DESCRIPTION
Right now you can provide a dictionary to the `cookies` param almost everywhere in Requests and it will be converted into a RequestsCookieJar (aka "just work"). The one place this isn't happening is with Session, which will accept a dictionary without complaint but then fail when you try to send a PreparedRequest. 

I discussed wanting to make this part of the API a bit more predictable with @Lukasa and this was a suggested fix for the problem. I did fair amount of testing outside of the included test and I don't believe this will adversely affect functionality. The one case I found is where someone is providing a CookieJar-like object that doesn't inherit from `cookielib.CookieJar`, and doesn't have an `__iter__` method. This seems like an unlikely case and wasn't _really_ supported before, so I wouldn't consider this breaking.
