### PR TITLE
Issue #3597 - Rework Bytestring Host Test to use PyTest Httpbin

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -858,11 +858,11 @@ class TestRequests:
         prep = s.prepare_request(req)
         assert prep.url == "https://httpbin.org/"
 
-    def test_request_with_bytestring_host(self):
+    def test_request_with_bytestring_host(self, httpbin):
         s = requests.Session()
         resp = s.request(
             'GET',
-            'http://httpbin.org/cookies/set?cookie=value',
+            httpbin('cookies/set?cookie=value'),
             allow_redirects=False,
             headers={'Host': b'httpbin.org'}
         )


### PR DESCRIPTION
Fixes dependency on internet connection for test added in PR #3598 for Issue #3597 