### PR TITLE
Remove error swallowing exception catching of AttributeError

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -747,18 +747,14 @@ class Response(object):
 
         if self._content is False:
             # Read the contents.
-            try:
-                if self._content_consumed:
-                    raise RuntimeError(
-                        'The content for this response was already consumed')
+            if self._content_consumed:
+                raise RuntimeError(
+                    'The content for this response was already consumed')
 
-                if self.status_code == 0:
-                    self._content = None
-                else:
-                    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
-
-            except AttributeError:
+            if self.status_code == 0:
                 self._content = None
+            else:
+                self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
 
         self._content_consumed = True
         # don't need to release the connection; that's been handled by urllib3


### PR DESCRIPTION
This exception catching is far too aggressive in my opinion. A lot of code could run in this and could throw AttributeError for any number of reasons. It's actually not clear to me what error it's trying to catch. It made it quite difficult for me to debug this problem: https://github.com/shazow/urllib3/pull/990

This PR removes it altogether since as far as I can see it is not needed in normal operation and can only serve to mask errors.