### PR TITLE
Update makefile to only ship tagged releases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,27 @@ certs:
 deps: urllib3 chardet
 
 urllib3:
-	git clone https://github.com/shazow/urllib3.git && rm -fr requests/packages/urllib3 && 	mv urllib3/urllib3 requests/packages/ && rm -fr urllib3
+	git clone https://github.com/shazow/urllib3.git && \
+	    rm -fr requests/packages/urllib3 && \
+	    cd urllib3 && \
+	    git checkout `git describe --abbrev=0 --tags` && \
+	    cd .. && \
+	    mv urllib3/urllib3 requests/packages/ \
+	    && rm -fr urllib3
 
 chardet:
-	git clone https://github.com/chardet/chardet.git && rm -fr requests/packages/chardet &&	mv chardet/chardet requests/packages/ && rm -fr chardet
+	git clone https://github.com/chardet/chardet.git && \
+	    rm -fr requests/packages/chardet && \
+	    cd chardet && \
+	    git checkout `git describe --abbrev=0 --tags` && \
+	    cd .. && \
+	    mv chardet/chardet requests/packages/ && \
+	    rm -fr chardet
 
 publish:
 	python setup.py register
 	python setup.py sdist upload
-	python setup.py bdist_wheel --universal upload 
+	python setup.py bdist_wheel --universal upload
 	rm -fr build dist .egg requests.egg-info
 
 


### PR DESCRIPTION
Extra work that spun out of #3620.

We've had it as our policy that we only ship tagged releases of our vendored modules for a while now. This makefile update consolidates that by ensuring that the makefile will only ever use the latest tag for updates.

For the moment this is probably a bit naive, because if any of our dependencies tagged backport releases we'd be totally screwed. Right now they don't, and I think we'll notice if they start doing it, so we should be safe.