### PR TITLE
Keep ``verify`` setting when no CA_BUNDLE variable exists

### DIFF
--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -674,7 +674,8 @@ class Session(SessionRedirectMixin):
             # with cURL.
             if verify is True or verify is None:
                 verify = (os.environ.get('REQUESTS_CA_BUNDLE') or
-                          os.environ.get('CURL_CA_BUNDLE'))
+                          os.environ.get('CURL_CA_BUNDLE') or
+                          verify)
 
         # Now we handle proxies.
         # Proxies need to be built up backwards. This is because None values

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1466,6 +1466,21 @@ class TestRequests:
         with pytest.raises(KeyError):
             proxies['http']
 
+    @pytest.fixture(autouse=True)
+    def test_merge_environment_settings_verify(self, monkeypatch):
+        """Assert CA environment settings are merged as expected when missing"""
+        session = requests.Session()
+        monkeypatch.delenv('CURL_CA_BUNDLE', raising=False)
+        monkeypatch.delenv('REQUESTS_CA_BUNDLE', raising=False)
+
+        assert session.trust_env is True
+        assert session.verify is True
+        assert 'REQUESTS_CA_BUNDLE' not in os.environ
+        assert 'CURL_CA_BUNDLE' not in os.environ
+        merged_settings = session.merge_environment_settings(
+            'http://example.com', {}, False, True, None)
+        assert merged_settings['verify'] is True
+
     def test_session_close_proxy_clear(self, mocker):
         proxies = {
           'one': mocker.Mock(),


### PR DESCRIPTION
If the ``trust_env`` flag is set on a session and ``verify`` is ``True``
or ``None``, the environment is checked for ``CURL_CA_BUNDLE`` and
``REQUESTS_CA_BUNDLE``. Before this patch, if neither existed,
``verify`` would always be set to ``None`` rather than ``True`` when it
was originally ``True``.

I found this while working on a patch for https://github.com/kennethreitz/requests/issues/3633.