### PR TITLE
The data= parameter barfs on all dictionary-like objects that don't subclass dict itself #3649

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -171,3 +171,4 @@ Patches and Suggestions
 - Michael Hunsinger
 - Brian Bamsch <bbamsch32@gmail.com> (`@bbamsch <https://github.com/bbamsch>`_)
 - Om Prakash Kumar <omprakash070@gmail.com> (`@iamprakashom <https://github.com/iamprakashom>`_)
+- Philipp Konrad <gardiac2002@gmail.com> (`@gardiac2002 <https://github.com/gardiac2002>`_)

--- a/requests/models.py
+++ b/requests/models.py
@@ -436,7 +436,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
 
         is_stream = all([
             hasattr(data, '__iter__'),
-            not isinstance(data, (basestring, list, tuple, dict))
+            not isinstance(data, (basestring, list, tuple, collections.Mapping))
         ])
 
         try:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -656,6 +656,31 @@ class TestRequests:
         with pytest.raises(ValueError):
             requests.post(url, files=['bad file data'])
 
+    def test_post_with_custom_mapping(self, httpbin):
+        class CustomMapping(collections.MutableMapping):
+            def __init__(self, *args, **kwargs):
+                self.data = dict(*args, **kwargs)
+
+            def __delitem__(self, key):
+                del self.data[key]
+
+            def __getitem__(self, key):
+                return self.data[key]
+
+            def __setitem__(self, key, value):
+                self.data[key] = value
+
+            def __iter__(self):
+                return iter(self.data)
+
+            def __len__(self):
+                return len(self.data)
+
+        data = CustomMapping({'some': 'data'})
+        url = httpbin('post')
+        found_json = requests.post(url, data=data).json().get('form')
+        assert found_json == {'some': 'data'}
+
     def test_conflicting_post_params(self, httpbin):
         url = httpbin('post')
         with open('requirements.txt') as f:


### PR DESCRIPTION
requests.post does not accept custom mappings as
data parameters. I changed the type check to Mapping.

Original bug report can be found at #3649:
The data= parameter barfs on all dictionary-like objects that don't subclass dict itself #3649