### PR TITLE
Accept integers in header

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -782,6 +782,9 @@ def check_header_validity(header):
     """
     name, value = header
 
+    if isinstance(value, int):
+        value = str(value)
+
     if isinstance(value, bytes):
         pat = _CLEAN_HEADER_REGEX_BYTE
     else:


### PR DESCRIPTION
This is a fix for the following crash of the utils.py I've encountered when syncing with vdirsyncer.

Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/vdirsyncer/cli/tasks.py", line 58, in sync_collection
    force_delete=force_delete
  File "/usr/lib/python3.5/site-packages/vdirsyncer/sync.py", line 169, in sync
    b_info.prepare_idents(storage_a.read_only)
  File "/usr/lib/python3.5/site-packages/vdirsyncer/sync.py", line 104, in prepare_idents
    for href, etag in self.storage.list():
  File "/usr/lib/python3.5/site-packages/vdirsyncer/storage/dav.py", line 565, in list
    headers=headers)
  File "/usr/lib/python3.5/site-packages/vdirsyncer/storage/dav.py", line 322, in request
    return utils.http.request(method, url, session=self._session, **more)
  File "/usr/lib/python3.5/site-packages/vdirsyncer/utils/http.py", line 79, in request
    r = func(method, url, **kwargs)
  File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 462, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python3.5/site-packages/requests/sessions.py", line 395, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/lib/python3.5/site-packages/requests/models.py", line 301, in prepare
    self.prepare_headers(headers)
  File "/usr/lib/python3.5/site-packages/requests/models.py", line 415, in prepare_headers
    check_header_validity(header)
  File "/usr/lib/python3.5/site-packages/requests/utils.py", line 794, in check_header_validity
    "not %s" % (value, type(value)))
requests.exceptions.InvalidHeader: Header value 1 must be of type str or bytes, not <class 'int'>

