### PR TITLE
Rewind readable body before POST redirect

### DIFF
--- a/requests/compat.py
+++ b/requests/compat.py
@@ -50,6 +50,7 @@ if is_py2:
     str = unicode
     basestring = basestring
     numeric_types = (int, long, float)
+    integer_types = (int, long)
 
 elif is_py3:
     from urllib.parse import urlparse, urlunparse, urljoin, urlsplit, urlencode, quote, unquote, quote_plus, unquote_plus, urldefrag
@@ -64,3 +65,4 @@ elif is_py3:
     bytes = bytes
     basestring = (str, bytes)
     numeric_types = (int, float)
+    integer_types = (int,)

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -100,6 +100,8 @@ class StreamConsumedError(RequestException, TypeError):
 class RetryError(RequestException):
     """Custom retries logic failed"""
 
+class UnrewindableBodyError(RequestException):
+    """Requests encountered an error when trying to rewind a body"""
 
 # Warnings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage==4.0.3
 decorator==4.0.9
 docutils==0.12
 Flask==0.10.1
-httpbin==0.4.1
+httpbin==0.5.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -165,6 +165,22 @@ class TestRequests:
         assert r.history[0].status_code == 302
         assert r.history[0].is_redirect
 
+    def test_HTTP_307_ALLOW_REDIRECT_POST(self, httpbin):
+        parts = urlparse(httpbin('post'))
+        url = "HTTP://" + parts.netloc + parts.path
+        r = requests.post(httpbin('redirect-to'), data='test', params={'url': url, 'status_code': 307})
+        assert r.status_code == 200
+        assert r.history[0].status_code == 307
+        assert r.history[0].is_redirect
+
+    def test_HTTP_307_ALLOW_REDIRECT_POST_WITH_SEEKABLE(self, httpbin):
+        parts = urlparse(httpbin('post'))
+        url = "HTTP://" + parts.netloc + parts.path
+        r = requests.post(httpbin('redirect-to'), data=io.BytesIO(b'test'), params={'url': url, 'status_code': 307})
+        assert r.status_code == 200
+        assert r.history[0].status_code == 307
+        assert r.history[0].is_redirect
+
     def test_HTTP_302_TOO_MANY_REDIRECTS(self, httpbin):
         try:
             requests.get(httpbin('relative-redirect', '50'))

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -24,7 +24,7 @@ from requests.cookies import (
 from requests.exceptions import (
     ConnectionError, ConnectTimeout, InvalidSchema, InvalidURL,
     MissingSchema, ReadTimeout, Timeout, RetryError, TooManyRedirects,
-    ProxyError, InvalidHeader)
+    ProxyError, InvalidHeader, UnrewindableBodyError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -166,20 +166,19 @@ class TestRequests:
         assert r.history[0].is_redirect
 
     def test_HTTP_307_ALLOW_REDIRECT_POST(self, httpbin):
-        parts = urlparse(httpbin('post'))
-        url = "HTTP://" + parts.netloc + parts.path
-        r = requests.post(httpbin('redirect-to'), data='test', params={'url': url, 'status_code': 307})
+        r = requests.post(httpbin('redirect-to'), data='test', params={'url': 'post', 'status_code': 307})
         assert r.status_code == 200
         assert r.history[0].status_code == 307
         assert r.history[0].is_redirect
+        assert r.json()['data'] == 'test'
 
     def test_HTTP_307_ALLOW_REDIRECT_POST_WITH_SEEKABLE(self, httpbin):
-        parts = urlparse(httpbin('post'))
-        url = "HTTP://" + parts.netloc + parts.path
-        r = requests.post(httpbin('redirect-to'), data=io.BytesIO(b'test'), params={'url': url, 'status_code': 307})
+        byte_str = b'test'
+        r = requests.post(httpbin('redirect-to'), data=io.BytesIO(byte_str), params={'url': 'post', 'status_code': 307})
         assert r.status_code == 200
         assert r.history[0].status_code == 307
         assert r.history[0].is_redirect
+        assert r.json()['data'] == byte_str.decode('utf-8')
 
     def test_HTTP_302_TOO_MANY_REDIRECTS(self, httpbin):
         try:


### PR DESCRIPTION
This addresses the issue (#3079) of Requests hanging when a POST with a file-like body encounters a temporary redirect. This currently has the unmerged tests from #3536, so I'll need to remove those if we reach a point where we're ready to merge this.

This approach has a couple of things that I'm not especially happy with but couldn't come up with a nicer alternative. I've added a few outstanding questions below.

1.) I feel like `body_position` should probably be `_body_position`, but we need to use it in the `Session` module. Making it a private var would require an additional getter method for `PreparedRequest` to expose the data to `Session`, but I wanted to run that by before adding more  code. It just seems problematic to provide any encouragement to manually set `body_position` since it will lead to fairly unintuitive behaviour.

2.) As I noted in the comment [here](https://github.com/nateprewitt/requests/commit/b84d71461e238b123a39ce91a48a99e3eb03717c#commitcomment-19619276), this still allows for the possibility that a request with a file-like object, that has tell but no seek, to hang. I feel like we should raise an `IOError` if we can't rewind, at least allowing the user to manually recreate the body and POST it to the new URL. Does that seem reasonable?
