### PR TITLE
json parameter added to patch and put methods

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -110,30 +110,32 @@ def post(url, data=None, json=None, **kwargs):
     return request('post', url, data=data, json=json, **kwargs)
 
 
-def put(url, data=None, **kwargs):
+def put(url, data=None, json=None, **kwargs):
     """Sends a PUT request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
+    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
     """
 
-    return request('put', url, data=data, **kwargs)
+    return request('put', url, data=data, json=json, **kwargs)
 
 
-def patch(url, data=None, **kwargs):
+def patch(url, data=None, json=None, **kwargs):
     """Sends a PATCH request.
 
     :param url: URL for the new :class:`Request` object.
     :param data: (optional) Dictionary, bytes, or file-like object to send in the body of the :class:`Request`.
+    :param json: (optional) json data to send in the body of the :class:`Request`.
     :param \*\*kwargs: Optional arguments that ``request`` takes.
     :return: :class:`Response <Response>` object
     :rtype: requests.Response
     """
 
-    return request('patch', url,  data=data, **kwargs)
+    return request('patch', url,  data=data, json=json, **kwargs)
 
 
 def delete(url, **kwargs):


### PR DESCRIPTION
referring to #2979 ...

this is answered that this can be done with **kwargs, which is true. But wouldn't that would go for **post** too ?
It would make consistent use of parameters possible if **put** and **patch** would support the _json_ parameter also, so then there is no need for additional logic to distinguish between the different methods, take for example:

```python
   ...
   self.client = requests.Session()  
   ...
   request_args = {}
   if method == 'get':
        request_args['params'] = params
   elif hasattr(endpoint, "data") and endpoint.data:
       request_args['json'] = endpoint.data
   ....
   func = getattr(self.client, method)
   response = func(url, stream=stream, headers=headers, **request_args)
   ...

```
post, put and patch can all be handled the same this way.