### PR TITLE
decoding fix for Streaming Requests docs

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -499,6 +499,20 @@ set ``stream`` to ``True`` and iterate over the response with
             decoded_line = line.decode('utf-8')
             print(json.loads(decoded_line))
 
+When using `decode_unicode=True` with
+:meth:`Response.iter_lines() <requests.Response.iter_lines>` or
+:meth:`Response.iter_content() <requests.Response.iter_content>`, you'll want
+to provide a fallback encoding in the event the server doesn't provide one::
+
+    r = requests.get('http://httpbin.org/stream/20', stream=True)
+
+    if r.encoding is None:
+        r.encoding = 'utf-8'
+
+    for line in r.iter_lines(decode_unicode=True):
+        if line:
+            print(json.loads(line))
+
 .. warning::
 
     :meth:`~requests.Response.iter_lines()` is not reentrant safe.

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -496,7 +496,8 @@ set ``stream`` to ``True`` and iterate over the response with
 
         # filter out keep-alive new lines
         if line:
-            print(json.loads(line))
+            decoded_line = line.decode('utf-8')
+            print(json.loads(decoded_line))
 
 .. warning::
 


### PR DESCRIPTION
This will address #3675 with 71b8941. I've added an additional commit (d81ad06) noting a suggested best practice of providing an encoding fallback when using the `decode_unicode` parameter. This is an optional improvement that I can strip if we only want the bare bones fix.