### PR TITLE
Amplifies the timeout warning in the docs.

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -484,7 +484,9 @@ Timeouts
 --------
 
 You can tell Requests to stop waiting for a response after a given number of
-seconds with the ``timeout`` parameter::
+seconds with the ``timeout`` parameter. Nearly all production code should use 
+this parameter in nearly all requests. Failure to do so can cause your program
+to hang indefinitely::
 
     >>> requests.get('http://github.com', timeout=0.001)
     Traceback (most recent call last):


### PR DESCRIPTION
Partially addresses #3070 until a fix can come in the next major version.