### PR TITLE
Add method to url tests

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2116,7 +2116,7 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_url(self, url, expected):
-        r = requests.Request(url=url)
+        r = requests.Request('GET', url=url)
         p = r.prepare()
         assert p.url == expected
 
@@ -2130,6 +2130,6 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_bad_url(self, url):
-        r = requests.Request(url=url)
+        r = requests.Request('GET', url=url)
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()


### PR DESCRIPTION
Looks like we forgot methods in the tests for #3620 😉

Proposed/3.0.0 is having a tantrum because we started checking for a non-None method there. We should probably get ahead of that and just patch it on master now though.