### PR TITLE
Fixes small readme typo - site => domain

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -423,8 +423,8 @@ suitable for use over multiple domains or paths.  Cookie jars can
 also be passed in to requests::
 
     >>> jar = requests.cookies.RequestsCookieJar()
-    >>> jar.set('tasty_cookie', 'yum', site='httpbin.org', path='/cookies')
-    >>> jar.set('gross_cookie', 'blech', site='httpbin.org', path='/elsewhere')
+    >>> jar.set('tasty_cookie', 'yum', domain='httpbin.org', path='/cookies')
+    >>> jar.set('gross_cookie', 'blech', domain='httpbin.org', path='/elsewhere')
     >>> url = 'http://httpbin.org/cookies'
     >>> r = requests.get(url, cookies=jar)
     >>> r.text


### PR DESCRIPTION
Fixed readme typo - 'site' should be 'domain'