### PR TITLE
Adding 'import requests' to readme code snippet.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests:
 
 .. code-block:: python
-
+    >>> import requests
     >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
     >>> r.status_code
     200

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,6 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests:
 
 .. code-block:: python
-    >>> import requests
     >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
     >>> r.status_code
     200

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests:
 
 .. code-block:: python
+
+    >>> import requests
     >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
     >>> r.status_code
     200

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests::
 
     >>> import requests
-    >>> r = requests.get('https://api.github.com/user', auth=('<your github username>', '<your github password>'))
+    >>> r = requests.get('https://api.github.com/user', auth=('<github username>', '<github password>'))
     >>> r.status_code
     200
     >>> r.headers['content-type']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests::
 
     >>> import requests
-    >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
+    >>> r = requests.get('https://api.github.com/user', auth=('<your github username>', '<your github password>'))
     >>> r.status_code
     200
     >>> r.headers['content-type']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ constantly reading documentation, depression, headaches, or even death.
 Behold, the power of Requests::
 
     >>> import requests
-    >>> r = requests.get('https://api.github.com/user', auth=('<github username>', '<github password>'))
+    >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
     >>> r.status_code
     200
     >>> r.headers['content-type']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ constantly reading documentation, depression, headaches, or even death.
 
 Behold, the power of Requests::
 
+    >>> import requests
     >>> r = requests.get('https://api.github.com/user', auth=('user', 'pass'))
     >>> r.status_code
     200


### PR DESCRIPTION
The interpreter snippet at the top of the readme.rst is the first snippet of code that users will see for using requests. I think an import statement should be shown at the top of the code snippet, so a novice or even intermediate python user will know to import the module first before attempting to use it. It makes the snippet more complete. I've seen other github projects include the import statement in snippets like the one in the readme. I changed the doc/index.rst file for consistency, since they are the same code snippet.