### PR TITLE
clarify that the `chunk_size` is optional when streaming to a file

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -184,7 +184,7 @@ streamed to a file::
 Using ``Response.iter_content`` will handle a lot of what you would otherwise
 have to handle when using ``Response.raw`` directly. When streaming a
 download, the above is the preferred and recommended way to retrieve the
-content. Note that `chunk_size` is optional.
+content. Note that ``chunk_size`` is optional.
 
 
 Custom Headers

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -184,7 +184,7 @@ streamed to a file::
 Using ``Response.iter_content`` will handle a lot of what you would otherwise
 have to handle when using ``Response.raw`` directly. When streaming a
 download, the above is the preferred and recommended way to retrieve the
-content.
+content. Note that `chunk_size` is optional.
 
 
 Custom Headers


### PR DESCRIPTION
Tripped me up briefly...figured others might run into the same thing. Thanks!