### PR TITLE
Added new function that returns json output in a pretty printed string form.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -173,3 +173,4 @@ Patches and Suggestions
 - Om Prakash Kumar <omprakash070@gmail.com> (`@iamprakashom <https://github.com/iamprakashom>`_)
 - Philipp Konrad <gardiac2002@gmail.com> (`@gardiac2002 <https://github.com/gardiac2002>`_)
 - Hussain Tamboli <hussaintamboli18@gmail.com> (`@hussaintamboli <https://github.com/hussaintamboli>`_)
+- Rakib Hasan

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -156,9 +156,26 @@ It should be noted that the success of the call to ``r.json()`` does **not**
 indicate the success of the response. Some servers may return a JSON object in a
 failed response (e.g. error details with HTTP 500). Such JSON will be decoded
 and returned. To check that a request is successful, use
-``r.raise_for_status()`` or check ``r.status_code`` is what you expect.
-
-
+``r.raise_for_status()`` or check ``r.status_code`` is what you expect. The function
+``r.sjson()`` will return the JSON object in string form. Printing the string will
+produce human readable output.::
+  >>> r.sjson()
+  [
+      {
+              "payload": {
+	                  "size": 2,
+			  "head": "9e69fa... ,
+			  "commits":[
+                               {
+			              "distinct": true,
+				      "sha": "8768b45551a... ,
+              ...
+	      
+	      "type": "PullRequestEvent",
+	      "public": true
+      }
+  ]
+	      
 Raw Response Content
 --------------------
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -159,7 +159,9 @@ and returned. To check that a request is successful, use
 ``r.raise_for_status()`` or check ``r.status_code`` is what you expect. The function
 ``r.sjson()`` will return the JSON object in string form. Printing the string will
 produce human readable output.::
-  >>> r.sjson()
+
+  >>> r = requests.get('https://api.github.com/events')
+  >>> print(r.sjson())
   [
       {
               "payload": {

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -158,7 +158,7 @@ failed response (e.g. error details with HTTP 500). Such JSON will be decoded
 and returned. To check that a request is successful, use
 ``r.raise_for_status()`` or check ``r.status_code`` is what you expect. The function
 ``r.sjson()`` will return the JSON object in string form. Printing the string will
-produce human readable output.::
+produce the following human readable output::
 
   >>> r = requests.get('https://api.github.com/events')
   >>> print(r.sjson())

--- a/requests/models.py
+++ b/requests/models.py
@@ -820,8 +820,8 @@ class Response(object):
     def sjson(self,**kwargs):
         """Gets the json-encoded content from self.json() in the form of a string
         :param \*\*kwargs: commands sent to the dumps function of module json
-        which affect the string returned from dumps. If kwargs is empty then
-        it returns a formated string with the json content
+        which affects the string returned from dumps(). If kwargs is empty then
+        it returns a formated string with the json content.
         """
 
         _json = self.json()

--- a/requests/models.py
+++ b/requests/models.py
@@ -823,7 +823,10 @@ class Response(object):
         :param \*\*kwargs: Optional arguments that ``json.loads`` takes.
         :raises ValueError: If the response body does not contain valid json.
         """
-
+        pretty_print = False
+        if 'pretty_print' in kwargs:
+            pretty_print = kwargs['pretty_print']
+            del kwargs['pretty_print']
         if not self.encoding and self.content and len(self.content) > 3:
             # No encoding set. JSON RFC 4627 section 3 states we should expect
             # UTF-8, -16 or -32. Detect which one to use; If the detection or
@@ -832,17 +835,19 @@ class Response(object):
             encoding = guess_json_utf(self.content)
             if encoding is not None:
                 try:
-                    return complexjson.loads(
+                    _json =  complexjson.loads(
                         self.content.decode(encoding), **kwargs
                     )
+                    return complexjson.dumps(_json,indent=4,separators=(',',': ')) if pretty_print == True else _json
                 except UnicodeDecodeError:
                     # Wrong UTF codec detected; usually because it's not UTF-8
                     # but some other 8-bit codec.  This is an RFC violation,
                     # and the server didn't bother to tell us what codec *was*
                     # used.
                     pass
-        return complexjson.loads(self.text, **kwargs)
-
+        _json =  complexjson.loads(self.text, **kwargs)
+        return complexjson.dumps(_json,indent=4,separators=(',',': ')) if pretty_print == True else _json
+                                
     @property
     def links(self):
         """Returns the parsed header links of the response, if any."""


### PR DESCRIPTION
The function sjson in the Response class will return a json object in string form. Unless provided arguments, it will return a pretty printed string, when printed is human readable. You can look at the docs for the json module's dumps object to know which arguments to send to the sjson function for custom output. 