### PR TITLE
Make Response.content() return None for an empty response

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -769,7 +769,7 @@ class Response(object):
                 raise RuntimeError(
                     'The content for this response was already consumed')
 
-            if self.status_code == 0:
+            if not self.status_code:
                 self._content = None
             else:
                 self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()

--- a/requests/models.py
+++ b/requests/models.py
@@ -769,7 +769,7 @@ class Response(object):
                 raise RuntimeError(
                     'The content for this response was already consumed')
 
-            if not self.status_code:
+            if self.status_code == 0 or self.raw is None:
                 self._content = None
             else:
                 self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1094,6 +1094,10 @@ class TestRequests:
         total_seconds = ((td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6)
         assert total_seconds > 0.0
 
+    def test_empty_response_has_content_none(self):
+        r = requests.Response()
+        assert r.content is None
+
     def test_response_is_iterable(self):
         r = requests.Response()
         io = StringIO.StringIO('abc')


### PR DESCRIPTION
Fix #3698.

This fixes also a traceback in https://github.com/galaxyproject/bioblend/blob/master/bioblend/galaxy/client.py#L135 where the `text` attribute of an empty `requests.Response()` object is used:
```
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/tests/TestGalaxyInstance.py", line 37, in test_get_retry
    self.gi.libraries.get_libraries()
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/bioblend/galaxy/libraries/__init__.py", line 218, in get_libraries
    libraries = self._get(deleted=deleted)
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/bioblend/galaxy/client.py", line 135, in _get
    raise ConnectionError(msg, body=r.text,
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/.tox/py27/local/lib/python2.7/site-packages/requests/models.py", line 796, in text
    if not self.content:
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/.tox/py27/local/lib/python2.7/site-packages/requests/models.py", line 772, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/usr/users/ga002/soranzon/software/galaxyproject_bioblend/.tox/py27/local/lib/python2.7/site-packages/requests/models.py", line 705, in generate
    chunk = self.raw.read(chunk_size)
AttributeError: 'NoneType' object has no attribute 'read'
```