### PR TITLE
Revert "Restrict URL preparation to HTTP/HTTPS"

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -347,9 +347,9 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         url = url.lstrip()
 
         # Don't do any URL preparation for non-HTTP schemes like `mailto`,
-        # `data`, `http+unix` etc to work around exceptions from `url_parse`,
-        # which handles RFC 3986 only.
-        if ':' in url and not url.lower().startswith(('http://', 'https://')):
+        # `data` etc to work around exceptions from `url_parse`, which
+        # handles RFC 3986 only.
+        if ':' in url and not url.lower().startswith('http'):
             self.url = url
             return
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2175,20 +2175,3 @@ class TestPreparingURLs(object):
         r = requests.Request('GET', url=url)
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()
-
-    @pytest.mark.parametrize(
-        'protocol, url',
-        (
-            ("http+unix://", b"http+unix://%2Fvar%2Frun%2Fsocket/path"),
-            ("http+unix://", u"http+unix://%2Fvar%2Frun%2Fsocket/path"),
-            ("mailto", b"mailto:user@example.org"),
-            ("mailto", u"mailto:user@example.org"),
-            ("data", b"data:SSDimaUgUHl0aG9uIQ=="),
-        )
-    )
-    def test_url_passthrough(self, protocol, url):
-        session = requests.Session()
-        session.mount(protocol, HTTPAdapter())
-        p = requests.Request('GET', url=url)
-        p.prepare()
-        assert p.url == url


### PR DESCRIPTION
This reverts commit 34af72c87d79bd8852e8564c050dd7711c6a08d6.

This commit was added by @tiran to try to avoid the IDNA-encoding logic that we added in v2.12.0. I believe that the *other* workarounds we merged for that are sufficient, and this change broke docker-py and probably broke others.

@tiran, can you confirm that your code continues to function with this change reverted? I'd like to be able to merge this and ship a v2.12.3 if at all possible.

Resolves #3735.