### PR TITLE
test auth doesn't generate incorrect http headers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -173,3 +173,4 @@ Patches and Suggestions
 - Om Prakash Kumar <omprakash070@gmail.com> (`@iamprakashom <https://github.com/iamprakashom>`_)
 - Philipp Konrad <gardiac2002@gmail.com> (`@gardiac2002 <https://github.com/gardiac2002>`_)
 - Hussain Tamboli <hussaintamboli18@gmail.com> (`@hussaintamboli <https://github.com/hussaintamboli>`_)
+- Casey Davidson (`@davidsoncasey <https://github.com/davidsoncasey>`_)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1716,6 +1716,14 @@ class TestRequests:
         assert 'Transfer-Encoding' not in prepared_request.headers
         assert 'Content-Length' in prepared_request.headers
 
+    def test_chunked_upload_does_not_set_content_length_header(self, httpbin):
+        data = (i for i in [b'a', b'b', b'c'])
+        url = httpbin('post')
+        r = requests.Request('POST', url, data=data)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' in prepared_request.headers
+        assert 'Content-Length' not in prepared_request.headers
+
 
 class TestCaseInsensitiveDict:
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1693,6 +1693,30 @@ class TestRequests:
         resp.close()
         assert resp.raw.closed
 
+    def test_empty_stream_with_auth_does_not_set_content_length_header(self, httpbin):
+        """Ensure that a byte stream with size 0 will not set both a Content-Length
+        and Transfer-Encoding header
+        """
+        auth = ('user', 'pass')
+        url = httpbin('post')
+        file_obj = io.BytesIO(b'')
+        r = requests.Request('POST', url, auth=auth, data=file_obj)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' in prepared_request.headers
+        assert 'Content-Length' not in prepared_request.headers
+
+    def test_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
+        """Ensure that a byte stream with size > 0 will not set both a Content-Length
+        and Transfer-Encoding header"""
+        auth = ('user', 'pass')
+        url = httpbin('post')
+        file_obj = io.BytesIO(b'test data')
+        r = requests.Request('POST', url, auth=auth, data=file_obj)
+        prepared_request = r.prepare()
+        assert 'Transfer-Encoding' not in prepared_request.headers
+        assert 'Content-Length' in prepared_request.headers
+
+
 class TestCaseInsensitiveDict:
 
     @pytest.mark.parametrize(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1695,7 +1695,7 @@ class TestRequests:
 
     def test_empty_stream_with_auth_does_not_set_content_length_header(self, httpbin):
         """Ensure that a byte stream with size 0 will not set both a Content-Length
-        and Transfer-Encoding header
+        and Transfer-Encoding header.
         """
         auth = ('user', 'pass')
         url = httpbin('post')
@@ -1707,7 +1707,8 @@ class TestRequests:
 
     def test_stream_with_auth_does_not_set_transfer_encoding_header(self, httpbin):
         """Ensure that a byte stream with size > 0 will not set both a Content-Length
-        and Transfer-Encoding header"""
+        and Transfer-Encoding header.
+        """
         auth = ('user', 'pass')
         url = httpbin('post')
         file_obj = io.BytesIO(b'test data')
@@ -1717,6 +1718,9 @@ class TestRequests:
         assert 'Content-Length' in prepared_request.headers
 
     def test_chunked_upload_does_not_set_content_length_header(self, httpbin):
+        """Ensure that requests with a generator body stream using
+        Transfer-Encoding: chunked, not a Content-Length header.
+        """
         data = (i for i in [b'a', b'b', b'c'])
         url = httpbin('post')
         r = requests.Request('POST', url, data=data)


### PR DESCRIPTION
These are a few tests from #3338 which is slated for Proposed/3.0.0. #3066 is the issue #3338 was originally opened to fix, but has since been resolved on master with #3082 and #3535. Adding these tests will allow us to confirm #3066 is indeed resolved and help prevent regressions until 3.0.0 is released.