### PR TITLE
301/302 redirects for non-POST with body

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,6 +1,9 @@
 3.0.0 (2016-xx-xx)
 ++++++++++++++++++
 
+- Relax how Requests strips bodies from redirects. 3.0.0 only supports body
+  removal on 301/302 POST redirects and all 303 redirects.
+
 - Remove support for non-string/bytes parameters in ``_basic_auth_str``.
 
 - Prevent ``Session.merge_environment`` from erroneously setting the

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -157,11 +157,13 @@ class SessionRedirectMixin(object):
             if response.is_permanent_redirect and request.url != prepared_request.url:
                 self.redirect_cache[request.url] = prepared_request.url
 
+            old_method = prepared_request.method
             self.rebuild_method(prepared_request, response)
+            new_method = prepared_request.method
 
-            # https://github.com/kennethreitz/requests/issues/1084
-            if response.status_code not in (codes.temporary_redirect,
-                    codes.permanent_redirect):
+            # https://github.com/kennethreitz/requests/issues/2590
+            # If method is changed to GET we need to remove body and associated headers.
+            if old_method != new_method and new_method == 'GET':
                 # https://github.com/kennethreitz/requests/issues/3490
                 purged_headers = ('Content-Length', 'Content-Type', 'Transfer-Encoding')
                 for header in purged_headers:
@@ -289,14 +291,12 @@ class SessionRedirectMixin(object):
         if response.status_code == codes.see_other and method != 'HEAD':
             method = 'GET'
 
-        # Do what the browsers do, despite standards...
-        # First, turn 302s into GETs.
-        if response.status_code == codes.found and method != 'HEAD':
-            method = 'GET'
-
-        # Second, if a POST is responded to with a 301, turn it into a GET.
-        # This bizarre behaviour is explained in Issue 1704.
-        if response.status_code == codes.moved and method == 'POST':
+        # If a POST is responded to with a 301 or 302, turn it into a GET. This has
+        # become a common pattern in browsers and was introduced into later versions
+        # of HTTP RFCs. While some browsers transform other methods to GET, little of
+        # that has been standardized. For that reason, we're using curl as a model
+        # which only supports POST->GET.
+        if response.status_code in (codes.found, codes.moved) and method == 'POST':
             method = 'GET'
 
         prepared_request.method = method

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -234,11 +234,51 @@ class TestRequests:
 
     def test_http_301_doesnt_change_head_to_get(self, httpbin):
         r = requests.head(httpbin('status', '301'), allow_redirects=True)
-        print(r.content)
         assert r.status_code == 200
         assert r.request.method == 'HEAD'
         assert r.history[0].status_code == 301
         assert r.history[0].is_redirect
+
+    def test_http_301_doesnt_change_non_post_to_get(self, httpbin):
+        r = requests.patch(httpbin('redirect-to'),
+                           data='test body',
+                           params={'url': 'patch', 'status_code': '301'})
+        assert r.status_code == 200
+        assert r.request.method == 'PATCH'
+        assert r.history[0].status_code == 301
+        assert r.history[0].is_redirect
+        assert r.request.body == 'test body'
+        assert r.json()['data'] == 'test body'
+
+    @pytest.mark.parametrize(
+        'method, body, expected', (
+            ('GET', None, 'GET'),
+            ('HEAD', None, 'HEAD'),
+            ('POST', 'test', 'GET'),
+            ('PUT', 'put test', 'PUT'),
+            ('PATCH', 'patch test', 'PATCH'),
+            ('DELETE', '', 'DELETE')
+        )
+    )
+    def test_http_301_for_redirectable_methods(self, httpbin, method, body, expected):
+        """Tests all methods except OPTIONS for expected redirect behaviour.
+
+        OPTIONS responses can behave differently depending on the server, so
+        we don't have anything uniform to test except how httpbin responds
+        to them. For that reason they aren't included here.
+        """
+        params = {'url': '/%s' % expected.lower(), 'status_code': '301'}
+        r = requests.request(method, httpbin('redirect-to'), data=body, params=params)
+
+        assert r.request.url == httpbin(expected.lower())
+        assert r.request.method == expected
+        assert r.history[0].status_code == 301
+        assert r.history[0].is_redirect
+
+        if expected in ('GET', 'HEAD'):
+            assert r.request.body is None
+        else:
+            assert r.json()['data'] == body
 
     def test_http_302_changes_post_to_get(self, httpbin):
         r = requests.post(httpbin('status', '302'))
@@ -254,6 +294,36 @@ class TestRequests:
         assert r.history[0].status_code == 302
         assert r.history[0].is_redirect
 
+    @pytest.mark.parametrize(
+        'method, body, expected', (
+            ('GET', None, 'GET'),
+            ('HEAD', None, 'HEAD'),
+            ('POST', 'test', 'GET'),
+            ('PUT', 'put test', 'PUT'),
+            ('PATCH', 'patch test', 'PATCH'),
+            ('DELETE', '', 'DELETE')
+        )
+    )
+    def test_http_302_for_redirectable_methods(self, httpbin, method, body, expected):
+        """Tests all methods except OPTIONS for expected redirect behaviour.
+
+        OPTIONS responses can behave differently depending on the server, so
+        we don't have anything uniform to test except how httpbin responds
+        to them. For that reason they aren't included here.
+        """
+        params = {'url': '/%s' % expected.lower()}
+        r = requests.request(method, httpbin('redirect-to'), data=body, params=params)
+
+        assert r.request.url == httpbin(expected.lower())
+        assert r.request.method == expected
+        assert r.history[0].status_code == 302
+        assert r.history[0].is_redirect
+
+        if expected in ('GET', 'HEAD'):
+            assert r.request.body is None
+        else:
+            assert r.json()['data'] == body
+
     def test_http_303_changes_post_to_get(self, httpbin):
         r = requests.post(httpbin('status', '303'))
         assert r.status_code == 200
@@ -267,6 +337,33 @@ class TestRequests:
         assert r.request.method == 'HEAD'
         assert r.history[0].status_code == 303
         assert r.history[0].is_redirect
+
+    @pytest.mark.parametrize(
+        'method, body, expected', (
+            ('GET', None, 'GET'),
+            ('HEAD', None, 'HEAD'),
+            ('POST', 'test', 'GET'),
+            ('PUT', 'put test', 'GET'),
+            ('PATCH', 'patch test', 'GET'),
+            ('DELETE', '', 'GET')
+        )
+    )
+    def test_http_303_for_redirectable_methods(self, httpbin, method, body, expected):
+        """Tests all methods except OPTIONS for expected redirect behaviour.
+
+        OPTIONS responses can behave differently depending on the server, so
+        we don't have anything uniform to test except how httpbin responds
+        to them. For that reason they aren't included here.
+        """
+        params = {'url': '/%s' % expected.lower(), 'status_code': '303'}
+        r = requests.request(method, httpbin('redirect-to'), data=body, params=params)
+
+        assert r.request.url == httpbin(expected.lower())
+        assert r.request.method == expected
+        assert r.history[0].status_code == 303
+        assert r.history[0].is_redirect
+
+        assert r.request.body is None
 
     def test_multiple_location_headers(self, httpbin):
         headers = [('Location', 'http://example.com'),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -225,31 +225,6 @@ class TestRequests:
         else:
             pytest.fail('Expected custom max number of redirects to be respected but was not')
 
-    def test_http_301_changes_post_to_get(self, httpbin):
-        r = requests.post(httpbin('status', '301'))
-        assert r.status_code == 200
-        assert r.request.method == 'GET'
-        assert r.history[0].status_code == 301
-        assert r.history[0].is_redirect
-
-    def test_http_301_doesnt_change_head_to_get(self, httpbin):
-        r = requests.head(httpbin('status', '301'), allow_redirects=True)
-        assert r.status_code == 200
-        assert r.request.method == 'HEAD'
-        assert r.history[0].status_code == 301
-        assert r.history[0].is_redirect
-
-    def test_http_301_doesnt_change_non_post_to_get(self, httpbin):
-        r = requests.patch(httpbin('redirect-to'),
-                           data='test body',
-                           params={'url': 'patch', 'status_code': '301'})
-        assert r.status_code == 200
-        assert r.request.method == 'PATCH'
-        assert r.history[0].status_code == 301
-        assert r.history[0].is_redirect
-        assert r.request.body == 'test body'
-        assert r.json()['data'] == 'test body'
-
     @pytest.mark.parametrize(
         'method, body, expected', (
             ('GET', None, 'GET'),
@@ -280,20 +255,6 @@ class TestRequests:
         else:
             assert r.json()['data'] == body
 
-    def test_http_302_changes_post_to_get(self, httpbin):
-        r = requests.post(httpbin('status', '302'))
-        assert r.status_code == 200
-        assert r.request.method == 'GET'
-        assert r.history[0].status_code == 302
-        assert r.history[0].is_redirect
-
-    def test_http_302_doesnt_change_head_to_get(self, httpbin):
-        r = requests.head(httpbin('status', '302'), allow_redirects=True)
-        assert r.status_code == 200
-        assert r.request.method == 'HEAD'
-        assert r.history[0].status_code == 302
-        assert r.history[0].is_redirect
-
     @pytest.mark.parametrize(
         'method, body, expected', (
             ('GET', None, 'GET'),
@@ -323,20 +284,6 @@ class TestRequests:
             assert r.request.body is None
         else:
             assert r.json()['data'] == body
-
-    def test_http_303_changes_post_to_get(self, httpbin):
-        r = requests.post(httpbin('status', '303'))
-        assert r.status_code == 200
-        assert r.request.method == 'GET'
-        assert r.history[0].status_code == 303
-        assert r.history[0].is_redirect
-
-    def test_http_303_doesnt_change_head_to_get(self, httpbin):
-        r = requests.head(httpbin('status', '303'), allow_redirects=True)
-        assert r.status_code == 200
-        assert r.request.method == 'HEAD'
-        assert r.history[0].status_code == 303
-        assert r.history[0].is_redirect
 
     @pytest.mark.parametrize(
         'method, body, expected', (


### PR DESCRIPTION
This patch is an attempt to address #2590 by relaxing the way Requests handles redirects. 

Taking a look at how we’re handling stripping bodies, I modified the conditional to avoid an overly complicated check. The only requests we want to strip bodies off of are ones that have been modified from the redirect. That means the method will have already been changed to GET in `rebuild_method` and we can perform a uniform stripping for only GET requests. Personally, I'd like to have `rebuild_method` return a value, either a boolean or the new method, and use that as the parameter for the check. Then move the code inside the conditional into it's own function. This will help a bit with the overall size of `resolve_redirects`.

I also removed the 302 catch-all which was put in place in #1704 when RFC 2616 was still the standard. The previous mandates for 302 aren’t included in [RFC 7231 6.4.3](https://tools.ietf.org/html/rfc7231#section-6.4.3) and don’t appear to be reproducible in Chrome or Firefox with any tools supporting PUT, PATCH, or DELETE. (Note: if there’s a repro for this that I’m missing please let me know and I’ll gladly revert this. I’m just going off of the information available.)

The "test all methods" tests may be a bit overboard, I added them primarily for my own assurance to make sure I wasn't missing edge cases. I can remove those if they're deemed unnecessary.