### PR TITLE
Revert "use enforce_content_length in Requests"

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -434,8 +434,7 @@ class HTTPAdapter(BaseAdapter):
                     preload_content=False,
                     decode_content=False,
                     retries=self.max_retries,
-                    timeout=timeout,
-                    enforce_content_length=True
+                    timeout=timeout
                 )
 
             # Send the request.
@@ -479,9 +478,7 @@ class HTTPAdapter(BaseAdapter):
                         pool=conn,
                         connection=low_conn,
                         preload_content=False,
-                        decode_content=False,
-                        enforce_content_length=True,
-                        request_method=request.method
+                        decode_content=False
                     )
                 except:
                     # If we hit any problems here, clean up the connection.

--- a/requests/models.py
+++ b/requests/models.py
@@ -28,8 +28,7 @@ from .packages.urllib3.fields import RequestField
 from .packages.urllib3.filepost import encode_multipart_formdata
 from .packages.urllib3.util import parse_url
 from .packages.urllib3.exceptions import (
-    DecodeError, ReadTimeoutError, ProtocolError,
-    LocationParseError, ConnectionError)
+    DecodeError, ReadTimeoutError, ProtocolError, LocationParseError)
 from .exceptions import (
     HTTPError, MissingScheme, InvalidURL, ChunkedEncodingError,
     ContentDecodingError, ConnectionError, StreamConsumedError)
@@ -708,10 +707,7 @@ class Response(object):
                     for chunk in self.raw.stream(chunk_size, decode_content=True):
                         yield chunk
                 except ProtocolError as e:
-                    if self.headers.get('Transfer-Encoding') == 'chunked':
-                        raise ChunkedEncodingError(e)
-                    else:
-                        raise ConnectionError(e)
+                    raise ChunkedEncodingError(e)
                 except DecodeError as e:
                     raise ContentDecodingError(e)
                 except ReadTimeoutError as e:

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -21,7 +21,7 @@ from ._internal_utils import to_native_string
 from .utils import to_key_val_list, default_headers
 from .exceptions import (
     TooManyRedirects, InvalidScheme, ChunkedEncodingError,
-    ConnectionError, ContentDecodingError, InvalidHeader)
+    ContentDecodingError, InvalidHeader)
 from .packages.urllib3._collections import RecentlyUsedContainer
 from .structures import CaseInsensitiveDict
 
@@ -115,7 +115,7 @@ class SessionRedirectMixin(object):
 
             try:
                 response.content  # Consume socket so it can be released
-            except (ChunkedEncodingError, ConnectionError, ContentDecodingError, RuntimeError):
+            except (ChunkedEncodingError, ContentDecodingError, RuntimeError):
                 response.raw.read(decode_content=False)
 
             # Don't exceed configured Session.max_redirects.

--- a/tests/test_lowlevel.py
+++ b/tests/test_lowlevel.py
@@ -24,23 +24,6 @@ def test_chunked_upload():
     assert r.status_code == 200
     assert r.request.headers['Transfer-Encoding'] == 'chunked'
 
-def test_incorrect_content_length():
-    """Test ConnectionError raised for incomplete responses"""
-    close_server = threading.Event()
-    server = Server.text_response_server(
-            "HTTP/1.1 200 OK\r\n" +
-            "Content-Length: 50\r\n\r\n" +
-            "Hello World."
-        )
-    with server as (host, port):
-        url = 'http://{0}:{1}/'.format(host, port)
-        r = requests.Request('GET', url).prepare()
-        s = requests.Session()
-        with pytest.raises(requests.exceptions.ConnectionError) as e:
-            resp = s.send(r)
-        assert "12 bytes read, 38 more expected" in str(e)
-        close_server.set()  # release server block
-
 
 _schemes_by_var_prefix = [
     ('http', ['http']),

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2363,7 +2363,7 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_url(self, url, expected):
-        r = requests.Request('GET', url=url)
+        r = requests.Request(url=url)
         p = r.prepare()
         assert p.url == expected
 
@@ -2378,7 +2378,7 @@ class TestPreparingURLs(object):
         )
     )
     def test_preparing_bad_url(self, url):
-        r = requests.Request('GET', url=url)
+        r = requests.Request(url=url)
         with pytest.raises(requests.exceptions.InvalidURL):
             r.prepare()
 


### PR DESCRIPTION
This is more of a TODO reminder. Given the upcoming work for urllib3 2.0, which I'm assuming will be used in a Requests 3.0.0, this won't work. We don't need to remove this immediately, but I'll leave this here for when we're sure 2.0 is happening.