### PR TITLE
Make code match behavior as defined in RFC 2818 and RFC 6125 and documented behavior

### DIFF
--- a/requests/packages/urllib3/packages/ssl_match_hostname/_implementation.py
+++ b/requests/packages/urllib3/packages/ssl_match_hostname/_implementation.py
@@ -132,7 +132,6 @@ def match_hostname(cert, hostname):
         elif key == 'IP Address':
             if host_ip is not None and _ipaddress_match(value, host_ip):
                 return
-            dnsnames.append(value)
     if not dnsnames:
         # The subject is only checked when there is no dNSName entry
         # in subjectAltName


### PR DESCRIPTION
The CN should be checked if no dNSName exist in subjectAltNames. The code treated a IP address as DNS name by appending it to dnsnames. This way CN was not checked in a certificate which contained the hostname as CN but only IP addresses as SAN.

See also http://stackoverflow.com/questions/41089539/authentication-issue-with-ssl-certificate-using-python-requests-lib