### PR TITLE
Reuse all connections

### DIFF
--- a/requests/api.py
+++ b/requests/api.py
@@ -12,6 +12,7 @@ This module implements the Requests API.
 
 from . import sessions
 
+session = sessions.Session()
 
 def request(method, url, **kwargs):
     """Constructs and sends a :class:`Request <Request>`.
@@ -49,11 +50,7 @@ def request(method, url, **kwargs):
       <Response [200]>
     """
 
-    # By using the 'with' statement we are sure the session is closed, thus we
-    # avoid leaving sockets open which can trigger a ResourceWarning in some
-    # cases, and look like a memory leak in others.
-    with sessions.Session() as session:
-        return session.request(method=method, url=url, **kwargs)
+    return session.request(method=method, url=url, **kwargs)
 
 
 def get(url, params=None, **kwargs):


### PR DESCRIPTION
When testing, every time I make a request, the message appears:

`` `Starting a new HTTP connection (1): www. *****. With

I have seen one session per application. He tried to reuse the "session" for all requests and seems to work properly, even with connections that have been closed.

What implications would this change have?



``` python
In [9]: requests.get("https://github.com")
Starting new HTTPS connection (1): github.com
Out[9]: <Response [200]>

In [10]: requests.get("https://github.com")
Out[10]: <Response [200]>

In [11]: requests.get("https://stackoverflow.com")
Starting new HTTPS connection (1): stackoverflow.com
Out[11]: <Response [200]>

In [12]: requests.get("https://stackoverflow.com")
Out[12]: <Response [200]>

In [13]: requests.get("https://github.com")
Out[13]: <Response [200]>

In [14]: requests.get("https://github.com")
Out[14]: <Response [200]>
```