### PR TITLE
remove HTTPProxyAuth in favor of the proxies parameter

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,6 +1,9 @@
 3.0.0 (2016-xx-xx)
 ++++++++++++++++++
 
+- Remove the HTTPProxyAuth class in favor of supporting proxy auth via
+  the proxies parameter.
+
 - Relax how Requests strips bodies from redirects. 3.0.0 only supports body
   removal on 301/302 POST redirects and all 303 redirects.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,7 +74,6 @@ Authentication
 
 .. autoclass:: requests.auth.AuthBase
 .. autoclass:: requests.auth.HTTPBasicAuth
-.. autoclass:: requests.auth.HTTPProxyAuth
 .. autoclass:: requests.auth.HTTPDigestAuth
 
 

--- a/requests/auth.py
+++ b/requests/auth.py
@@ -77,14 +77,6 @@ class HTTPBasicAuth(AuthBase):
         return r
 
 
-class HTTPProxyAuth(HTTPBasicAuth):
-    """Attaches HTTP Proxy Authentication to a given Request object."""
-
-    def __call__(self, r):
-        r.headers['Proxy-Authorization'] = _basic_auth_str(self.username, self.password)
-        return r
-
-
 class HTTPDigestAuth(AuthBase):
     """Attaches HTTP Digest Authentication to the given Request object."""
 


### PR DESCRIPTION
Minor tweak for 3.0.0 to cross off #2003 by removing the HTTPProxyAuth class in favor of the `proxies` param.