### PR TITLE
Lazy load idna to free memory

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -174,3 +174,4 @@ Patches and Suggestions
 - Philipp Konrad <gardiac2002@gmail.com> (`@gardiac2002 <https://github.com/gardiac2002>`_)
 - Hussain Tamboli <hussaintamboli18@gmail.com> (`@hussaintamboli <https://github.com/hussaintamboli>`_)
 - Casey Davidson (`@davidsoncasey <https://github.com/davidsoncasey>`_)
+- Moinuddin Quadri <moin18@gmail.com> (`@moin18 <https://github.com/moin18>`_)

--- a/requests/_internal_utils.py
+++ b/requests/_internal_utils.py
@@ -10,6 +10,8 @@ which depend on extremely few external helpers (such as compat)
 
 from .compat import is_py2, builtin_str, str
 
+import sys
+
 
 def to_native_string(string, encoding='ascii'):
     """Given a string object, regardless of type, returns a representation of
@@ -40,3 +42,31 @@ def unicode_is_ascii(u_string):
         return True
     except UnicodeEncodeError:
         return False
+
+
+def delete_module(modname):
+    """
+    Delete module and sub-modules from `sys.module`
+    """
+    try:
+        _ = sys.modules[modname]
+    except KeyError:
+        raise ValueError("Module not found in sys.modules: '{}'".format(modname))
+
+    for module in list(sys.modules.keys()):
+        if module and module.startswith(modname):
+            del sys.modules[module]
+
+
+def reload_module(module):
+    try:
+        # For Python 2.x
+        reload(module)
+    except (ImportError, NameError):
+        # For <= Python3.3:
+        import imp
+        imp.reload(module)
+    except (ImportError, NameError):
+        # For >= Python3.4
+        import importlib
+        importlib.reload(module)

--- a/requests/packages/__init__.py
+++ b/requests/packages/__init__.py
@@ -34,9 +34,3 @@ try:
 except ImportError:
     import chardet
     sys.modules['%s.chardet' % __name__] = chardet
-
-try:
-    from . import idna
-except ImportError:
-    import idna
-    sys.modules['%s.idna' % __name__] = idna

--- a/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/requests/packages/urllib3/contrib/pyopenssl.py
@@ -43,7 +43,6 @@ set the ``urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST`` variable.
 """
 from __future__ import absolute_import
 
-import idna
 import OpenSSL.SSL
 from cryptography import x509
 from cryptography.hazmat.backends.openssl import backend as openssl_backend
@@ -138,6 +137,7 @@ def _dnsname_to_stdlib(name):
     then on Python 3 we also need to convert to unicode via UTF-8 (the stdlib
     uses PyUnicode_FromStringAndSize on it, which decodes via UTF-8).
     """
+    @util.decorators.load_idna
     def idna_encode(name):
         """
         Borrowed wholesale from the Python Cryptography Project. It turns out

--- a/requests/packages/urllib3/util/decorators.py
+++ b/requests/packages/urllib3/util/decorators.py
@@ -1,0 +1,54 @@
+import sys
+
+
+def delete_module(modname):
+    """
+    Delete module and sub-modules from `sys.module`
+    """
+    try:
+        _ = sys.modules[modname]
+    except KeyError:
+        raise ValueError("Module not found in sys.modules: '{}'".format(modname))
+
+    for module in list(sys.modules.keys()):
+        if module and module.startswith(modname):
+            del sys.modules[module]
+
+
+def reload_module(module):
+    try:
+        # For Python 2.x
+        reload(module)
+    except (ImportError, NameError):
+        # For <= Python3.3:
+        import imp
+        imp.reload(module)
+    except (ImportError, NameError):
+        # For >= Python3.4
+        import importlib
+        importlib.reload(module)
+
+def load_idna(func):
+    """
+    Decorator to load idna to execute idna related operation for specific function
+    and delete the idna module from imports once the task is done.
+    Needed to free the memory consumed due to idna imports.
+    """
+    def inner(*args, **kwargs):
+        import idna
+
+        # Add `idna` entry in `sys.modules`. After deleting the module
+        # from `sys.modules` and re-importing the module don't update
+        # the module entry in `sys.modules` dict
+        sys.modules[idna.__package__] = idna
+
+        reload_module(idna)
+
+        value = func(*args, **kwargs)
+
+        # delete idna module
+        delete_module('idna')
+        del idna  # delete reference to idna
+
+        return value
+    return inner


### PR DESCRIPTION
Fix for issue: https://github.com/kennethreitz/requests/issues/3780

Lazily loading `idna`. This CR includes utilities to:
* lazily load idna package
* And, delete module from sys.modules after use

Changes looks to work fine for me. Now, None of the reference to `idna` is getting used directly. GC will release the memory when required.