### PR TITLE
Require pytest-mock for the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ packages = [
 ]
 
 requires = []
-test_requirements = ['pytest>=2.8.0', 'pytest-httpbin==0.0.7', 'pytest-cov']
+test_requirements = ['pytest>=2.8.0', 'pytest-httpbin==0.0.7', 'pytest-cov', 'pytest-mock']
 
 with open('requests/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',


### PR DESCRIPTION
test_requests.py `test_session_close_proxy_clear` uses the
`mocker` fixture, which is provided by pytest-mock.