### PR TITLE
Remove unused module from tests

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -20,7 +20,7 @@ from requests.compat import (
     Morsel, cookielib, getproxies, str, urlparse,
     builtin_str, OrderedDict)
 from requests.cookies import (
-    cookiejar_from_dict, morsel_to_cookie, merge_cookies)
+    cookiejar_from_dict, morsel_to_cookie)
 from requests.exceptions import (
     ConnectionError, ConnectTimeout, InvalidSchema, InvalidURL,
     MissingSchema, ReadTimeout, Timeout, RetryError, TooManyRedirects,
@@ -2293,4 +2293,3 @@ class TestPreparingURLs(object):
         r = requests.Request('GET', url=input, params=params)
         p = r.prepare()
         assert p.url == expected
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 import pytest
 from requests import compat
-from requests.cookies import RequestsCookieJar, cookiejar_from_dict
+from requests.cookies import RequestsCookieJar
 from requests.structures import CaseInsensitiveDict
 from requests.utils import (
     address_in_network, dotted_netmask,


### PR DESCRIPTION
merge_cookies and cookiejar_from_dict functions are already tested by other test functions.