### PR TITLE
Add ability to load ca bundle from data

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -175,3 +175,4 @@ Patches and Suggestions
 - Hussain Tamboli <hussaintamboli18@gmail.com> (`@hussaintamboli <https://github.com/hussaintamboli>`_)
 - Casey Davidson (`@davidsoncasey <https://github.com/davidsoncasey>`_)
 - Andrii Soldatenko (`@a_soldatenko <https://github.com/andriisoldatenko>`_)
+- Ilya Kulakov (`@kentzo <https://github.com/kentzo>`_)

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -221,10 +221,15 @@ class HTTPAdapter(BaseAdapter):
 
             conn.cert_reqs = 'CERT_REQUIRED'
 
-            if not os.path.isdir(cert_loc):
-                conn.ca_certs = cert_loc
-            else:
-                conn.ca_cert_dir = cert_loc
+            try:
+                if os.path.isfile(cert_loc):
+                    conn.ca_certs = cert_loc
+                elif os.path.isdir(cert_loc):
+                    conn.ca_cert_dir = cert_loc
+                else:
+                    conn.ca_certs_data = cert_loc
+            except:
+                conn.ca_certs_data = cert_loc
         else:
             conn.cert_reqs = 'CERT_NONE'
             conn.ca_certs = None

--- a/requests/packages/urllib3/connection.py
+++ b/requests/packages/urllib3/connection.py
@@ -248,13 +248,14 @@ class VerifiedHTTPSConnection(HTTPSConnection):
     cert_reqs = None
     ca_certs = None
     ca_cert_dir = None
+    ca_certs_data = None
     ssl_version = None
     assert_fingerprint = None
 
     def set_cert(self, key_file=None, cert_file=None,
                  cert_reqs=None, ca_certs=None,
                  assert_hostname=None, assert_fingerprint=None,
-                 ca_cert_dir=None):
+                 ca_cert_dir=None, ca_certs_data=None):
         """
         This method should only be called once, before the connection is used.
         """
@@ -275,6 +276,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
         self.assert_fingerprint = assert_fingerprint
         self.ca_certs = ca_certs and os.path.expanduser(ca_certs)
         self.ca_cert_dir = ca_cert_dir and os.path.expanduser(ca_cert_dir)
+        self.ca_certs_data = ca_certs_data
 
     def connect(self):
         # Add certificate verification
@@ -319,6 +321,7 @@ class VerifiedHTTPSConnection(HTTPSConnection):
             certfile=self.cert_file,
             ca_certs=self.ca_certs,
             ca_cert_dir=self.ca_cert_dir,
+            ca_certs_data=self.ca_certs_data,
             server_hostname=hostname,
             ssl_context=context)
 

--- a/requests/packages/urllib3/connectionpool.py
+++ b/requests/packages/urllib3/connectionpool.py
@@ -732,7 +732,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
     If ``assert_hostname`` is False, no verification is done.
 
     The ``key_file``, ``cert_file``, ``cert_reqs``, ``ca_certs``,
-    ``ca_cert_dir``, and ``ssl_version`` are only used if :mod:`ssl` is
+    ``ca_cert_dir``, ``ca_certs_data`` and ``ssl_version`` are only used if :mod:`ssl` is
     available and are fed into :meth:`urllib3.util.ssl_wrap_socket` to upgrade
     the connection socket into an SSL socket.
     """
@@ -747,7 +747,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                  key_file=None, cert_file=None, cert_reqs=None,
                  ca_certs=None, ssl_version=None,
                  assert_hostname=None, assert_fingerprint=None,
-                 ca_cert_dir=None, **conn_kw):
+                 ca_cert_dir=None, ca_certs_data=None, **conn_kw):
 
         HTTPConnectionPool.__init__(self, host, port, strict, timeout, maxsize,
                                     block, headers, retries, _proxy, _proxy_headers,
@@ -761,6 +761,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         self.cert_reqs = cert_reqs
         self.ca_certs = ca_certs
         self.ca_cert_dir = ca_cert_dir
+        self.ca_certs_data = ca_certs_data
         self.ssl_version = ssl_version
         self.assert_hostname = assert_hostname
         self.assert_fingerprint = assert_fingerprint
@@ -777,6 +778,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
                           cert_reqs=self.cert_reqs,
                           ca_certs=self.ca_certs,
                           ca_cert_dir=self.ca_cert_dir,
+                          ca_certs_data=self.ca_certs_data,
                           assert_hostname=self.assert_hostname,
                           assert_fingerprint=self.assert_fingerprint)
             conn.ssl_version = self.ssl_version

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1740,6 +1740,15 @@ class TestRequests:
         assert 'Transfer-Encoding' in prepared_request.headers
         assert 'Content-Length' not in prepared_request.headers
 
+    def test_verify_with_data(self, httpbin_secure, httpbin_ca_bundle):
+        from requests.certs import where
+
+        with open(where(), mode='r') as f:
+            data = ''.join([l for l in f.readlines() if not l.startswith('#')])
+
+        r = requests.get('https://httpbin.org/', verify=data)
+        assert r.status_code == 200
+
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
SSLContext.load_verify_locations allows to specify cadata with 2.7.9+, 3.4+