### PR TITLE
Only load .packages.urllib3.contrib.pyopenssl if we have an old version of OpenSSL.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -175,3 +175,4 @@ Patches and Suggestions
 - Hussain Tamboli <hussaintamboli18@gmail.com> (`@hussaintamboli <https://github.com/hussaintamboli>`_)
 - Casey Davidson (`@davidsoncasey <https://github.com/davidsoncasey>`_)
 - Andrii Soldatenko (`@a_soldatenko <https://github.com/andriisoldatenko>`_)
+- Dan Sully (`@dsully <https://github.com/dsully>`_)

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -56,7 +56,7 @@ __copyright__ = 'Copyright 2016 Kenneth Reitz'
 # See https://github.com/kennethreitz/requests/issues/3213 as well.
 import ssl
 
-if ssl.OPENSSL_VERSION_INFO < (1, 0, 1):
+if hasattr(ssl, 'OPENSSL_VERSION_INFO') and getattr(ssl, 'OPENSSL_VERSION_INFO') < (1, 0, 1):
     try:
         from .packages.urllib3.contrib import pyopenssl
         pyopenssl.inject_into_urllib3()

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -48,11 +48,20 @@ __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2016 Kenneth Reitz'
 
 # Attempt to enable urllib3's SNI support, if possible
-try:
-    from .packages.urllib3.contrib import pyopenssl
-    pyopenssl.inject_into_urllib3()
-except ImportError:
-    pass
+# If the user has a recent version of OpenSSL, this
+# isn't needed as Python's core ssl module handles SNI, etc correctly.
+# If the requirements of urllib3.contrib.pyopenssl change,
+# this version should be modified appropraitely.
+#
+# See https://github.com/kennethreitz/requests/issues/3213 as well.
+import ssl
+
+if ssl.OPENSSL_VERSION_INFO < (1, 0, 1):
+    try:
+        from .packages.urllib3.contrib import pyopenssl
+        pyopenssl.inject_into_urllib3()
+    except ImportError:
+        pass
 
 import warnings
 


### PR DESCRIPTION
See issue #3213