### PR TITLE
Blacklist known bad version of pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 init:
-	pip install 'pipenv===0.2.0'
+	pip install 'pipenv>=0.1.6,!=0.2.6,!=0.2.7,!=0.2.8'
 	pipenv install --dev
 
 test:


### PR DESCRIPTION
We pinned pipenv to release v2.13.0 but in reality, we could have just
blacklisted the known bad version. For future us, we now blacklist it.