### PR TITLE
fixing codecov with pipenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install: "make"
 script:
   - make coverage
 after_success:
-  - codecov
+  - pipenv run codecov


### PR DESCRIPTION
codecov broke with the introduction of pipenv because the dependency isn't installed outside of the virtualenv. Running it inside of pipenv fixes this.