### PR TITLE
initial attempt at `get_redirect_target`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -177,3 +177,5 @@ Patches and Suggestions
 - Andrii Soldatenko (`@a_soldatenko <https://github.com/andriisoldatenko>`_)
 - Moinuddin Quadri <moin18@gmail.com> (`@moin18 <https://github.com/moin18>`_)
 - Matt Kohl (`@mattkohl <https://github.com/mattkohl>`_)
+- Jonathan Vanasco (`@jvanasco <https://github.com/jvanasco>`_)
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ---------------
 
+**Unreleased**
++++++++++++++++++++
+
+- The behavior of ``SessionRedirectMixin`` was slightly altered.
+  ``resolve_redirects`` will now detect a redirect by calling
+  ``get_redirect_target(response)`` instead of directly
+  querying ``Response.is_redirect`` and ``Response.headers['location']``.
+  Advanced users will be able to process malformed redirects more easily.
+
 2.13.0 (2017-01-24)
 +++++++++++++++++++
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1740,6 +1740,49 @@ class TestRequests:
         assert 'Transfer-Encoding' in prepared_request.headers
         assert 'Content-Length' not in prepared_request.headers
 
+    def test_custom_redirect_mixin(self, httpbin):
+        """Tests a custom mixin to overwrite ``get_redirect_target``.
+
+        Ensures a subclassed ``requests.Session`` can handle a certain type of
+        malformed redirect responses.
+
+        1. original request receives a proper response: 302 redirect
+        2. following the redirect, a malformed response is given:
+            status code = HTTP 200
+            location = alternate url
+        3. the custom session catches the edge case and follows the redirect
+        """
+        url_final = httpbin('html')
+        querystring_malformed = urlencode({'location': url_final})
+        url_redirect_malformed = httpbin('response-headers?%s' % querystring_malformed)
+        querystring_redirect = urlencode({'url': url_redirect_malformed})
+        url_redirect = httpbin('redirect-to?%s' % querystring_redirect)
+        urls_test = [url_redirect,
+                     url_redirect_malformed,
+                     url_final,
+                     ]
+
+        class CustomRedirectSession(requests.Session):
+            def get_redirect_target(self, resp):
+                # default behavior
+                if resp.is_redirect:
+                    return resp.headers['location']
+                # edge case - check to see if 'location' is in headers anyways
+                location = resp.headers.get('location')
+                if location and (location != resp.url):
+                    return location
+                return None
+
+        session = CustomRedirectSession()
+        r = session.get(urls_test[0])
+        assert len(r.history) == 2
+        assert r.status_code == 200
+        assert r.history[0].status_code == 302
+        assert r.history[0].is_redirect
+        assert r.history[1].status_code == 200
+        assert not r.history[1].is_redirect
+        assert r.url == urls_test[2]
+
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
This is the first attempt at a PR to address my proposal #3837 to support pluggable redirect handling.  Feedback is welcome.

This does not break existing tests and adds a new test to for handling malformed 200+location responses using a custom session mixin.

I've been testing it for a day and it seems to be fine.

Thank you for simply considering this, and even more thanks for all the suggestions and advice in the related thread.  It has been a long week of little sleep trying to pin down some issues.  