### PR TITLE
remove pin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: docs
 
 init:
-	pip install pipenv==3.1.9
+	pip install pipenv
 	pipenv lock
 	pipenv install --dev
 


### PR DESCRIPTION
@kennethreitz, it looks like the Pipfile was rebuilt yesterday with the latest version of `pipenv`. We'll need to remove the version we had pinned now that kennethreitz/pipenv#90 is resolved.