### PR TITLE
Do not convert /o\ into /O\

### DIFF
--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -87,5 +87,5 @@ codes = LookupDict(name='status_codes')
 for code, titles in _codes.items():
     for title in titles:
         setattr(codes, title, code)
-        if not if not title.startswith(('\\', '/')):
+        if not title.startswith(('\\', '/')):
             setattr(codes, title.upper(), code)

--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -87,5 +87,5 @@ codes = LookupDict(name='status_codes')
 for code, titles in _codes.items():
     for title in titles:
         setattr(codes, title, code)
-        if not title.startswith('\\') and not title.strartswith('/'):
+        if not if not title.startswith(('\\', '/')):
             setattr(codes, title.upper(), code)

--- a/requests/status_codes.py
+++ b/requests/status_codes.py
@@ -87,5 +87,5 @@ codes = LookupDict(name='status_codes')
 for code, titles in _codes.items():
     for title in titles:
         setattr(codes, title, code)
-        if not title.startswith('\\'):
+        if not title.startswith('\\') and not title.strartswith('/'):
             setattr(codes, title.upper(), code)


### PR DESCRIPTION
There is code that already check that a guy raising (at least) his right arm does not get big-headed (a.k.a uppercased). Just add the same for the other, poor guy complaining about an error.