### PR TITLE
More extensive while-loop altering

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -177,3 +177,5 @@ Patches and Suggestions
 - Andrii Soldatenko (`@a_soldatenko <https://github.com/andriisoldatenko>`_)
 - Moinuddin Quadri <moin18@gmail.com> (`@moin18 <https://github.com/moin18>`_)
 - Matt Kohl (`@mattkohl <https://github.com/mattkohl>`_)
+- Jonathan Vanasco (`@jvanasco <https://github.com/jvanasco>`_)
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 Release History
 ---------------
 
+**Unreleased**
++++++++++++++++++++
+
+- The behavior of ``SessionRedirectMixin`` was slightly altered.
+  ``resolve_redirects`` will now detect a redirect by calling
+  ``get_redirect_target(response)`` instead of directly
+  querying ``Response.is_redirect`` and ``Response.headers['location']``.
+  Advanced users will be able to process malformed redirects more easily.
+
 2.13.0 (2017-01-24)
 +++++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ Release History
   querying ``Response.is_redirect`` and ``Response.headers['location']``.
   Advanced users will be able to process malformed redirects more easily.
 
+- Altered how ``SessionRedirectMixin.resolve_redirects`` and ``Session.send``
+  process redirect history.
+
 2.13.0 (2017-01-24)
 +++++++++++++++++++
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -97,16 +97,11 @@ class SessionRedirectMixin(object):
                           verify=True, cert=None, proxies=None, **adapter_kwargs):
         """Receives a Response. Returns a generator of Responses."""
 
-        hist = [] # keep track of history
+        hist = [resp, ] # keep track of history; seed it with the original response
 
         url = self.get_redirect_target(resp)
         while url:
             prepared_request = req.copy()
-
-            # Update history and keep track of redirects.
-            # resp.history must ignore the original request in this loop
-            hist.append(resp)
-            resp.history = hist[1:]
 
             try:
                 resp.content  # Consume socket so it can be released
@@ -193,6 +188,10 @@ class SessionRedirectMixin(object):
                 allow_redirects=False,
                 **adapter_kwargs
             )
+            # copy our history tracker into the response
+            resp.history = hist[:]
+            # append the new response to the history tracker for the next iteration
+            hist.append(resp)
 
             extract_cookies_to_jar(self.cookies, prepared_request, resp.raw)
 
@@ -634,13 +633,9 @@ class Session(SessionRedirectMixin):
         # Resolve redirects if allowed.
         history = [resp for resp in gen] if allow_redirects else []
 
-        # Shuffle things around if there's history.
+        # if there is a history, replace ``r`` with the last response
         if history:
-            # Insert the first (original) request at the start
-            history.insert(0, r)
-            # Get the last request made
             r = history.pop()
-            r.history = history
 
         if not stream:
             r.content

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1740,6 +1740,49 @@ class TestRequests:
         assert 'Transfer-Encoding' in prepared_request.headers
         assert 'Content-Length' not in prepared_request.headers
 
+    def test_custom_redirect_mixin(self, httpbin):
+        """Tests a custom mixin to overwrite ``get_redirect_target``.
+
+        Ensures a subclassed ``requests.Session`` can handle a certain type of
+        malformed redirect responses.
+
+        1. original request receives a proper response: 302 redirect
+        2. following the redirect, a malformed response is given:
+            status code = HTTP 200
+            location = alternate url
+        3. the custom session catches the edge case and follows the redirect
+        """
+        url_final = httpbin('html')
+        querystring_malformed = urlencode({'location': url_final})
+        url_redirect_malformed = httpbin('response-headers?%s' % querystring_malformed)
+        querystring_redirect = urlencode({'url': url_redirect_malformed})
+        url_redirect = httpbin('redirect-to?%s' % querystring_redirect)
+        urls_test = [url_redirect,
+                     url_redirect_malformed,
+                     url_final,
+                     ]
+
+        class CustomRedirectSession(requests.Session):
+            def get_redirect_target(self, resp):
+                # default behavior
+                if resp.is_redirect:
+                    return resp.headers['location']
+                # edge case - check to see if 'location' is in headers anyways
+                location = resp.headers.get('location')
+                if location and (location != resp.url):
+                    return location
+                return None
+
+        session = CustomRedirectSession()
+        r = session.get(urls_test[0])
+        assert len(r.history) == 2
+        assert r.status_code == 200
+        assert r.history[0].status_code == 302
+        assert r.history[0].is_redirect
+        assert r.history[1].status_code == 200
+        assert not r.history[1].is_redirect
+        assert r.url == urls_test[2]
+
 
 class TestCaseInsensitiveDict:
 


### PR DESCRIPTION
This is offered as an alternate/addition to my other PR, https://github.com/kennethreitz/requests/pull/3846

Specifically the code is in this commit: https://github.com/jvanasco/requests/commit/5e9371854176164db9ce5fee5ceb39b58f4035b2

This passes current tests, but it's a bit of a change so I'm offering it separately.

The existing redirect code was incredibly confusing, because objects were being overwritten mid-loop, select items had to be removed, and then everything needed to be switched back again.

This approach does a major reorganization of the logic, but I think for the better:

# SessionRedirectMixin.resolve_redirects

The `hist` tracker makes more sense.

* `hist` is started off with the original response. 
* after the redirect response is created, it is updated with the "current" history
* `hist` is then updated with the new response

# Session.send

Because the `Request.history` was carefully constructed within the loop context, the history had to then be shuffled around and response updated.  The above change makes that unnecessary, and instead `r ` is just popped off and used as-is.

I think this makes the code easier to read and maintain, and it removes that weird shuffle at the end.  It's a bit of a change though, and might break the API in a way that is currently untested.

