### PR TITLE
revert removal of request param from resolve_redirects

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,4 +1,4 @@
-3.0.0 (2016-xx-xx)
+3.0.0 (2017-xx-xx)
 ++++++++++++++++++
 
 - Remove the HTTPProxyAuth class in favor of supporting proxy auth via
@@ -43,7 +43,8 @@
   the end of a request body's transmission, skipping them allows all of the
   data through. See `#2631`_ for more details.
 
-- Remove the ``req`` argument from ``Session.resolve_redirects`` method.
+- Rename the ``req`` argument from ``Session.resolve_redirects`` method
+  to ``request``.
 
 - Rename the ``resp`` argument from ``Session.resolve_redirects`` to
   ``response``.

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -87,7 +87,7 @@ def merge_hooks(request_hooks, session_hooks, dict_class=OrderedDict):
 
 
 class SessionRedirectMixin(object):
-    def resolve_redirects(self, response, stream=False, timeout=None,
+    def resolve_redirects(self, response, request, stream=False, timeout=None,
                           verify=True, cert=None, proxies=None, **adapter_kwargs):
         """Given a Response, yields Responses until 'Location' header-based
         redirection ceases, or the Session.max_redirects limit has been
@@ -96,7 +96,6 @@ class SessionRedirectMixin(object):
 
         redirect_count = 0
         history = [] # keep track of history
-        request = response.request
 
         while response.is_redirect:
             if not is_valid_location(response):
@@ -649,7 +648,7 @@ class Session(SessionRedirectMixin):
         extract_cookies_to_jar(self.cookies, request, r.raw)
 
         # Redirect resolving generator.
-        gen = self.resolve_redirects(r, **kwargs)
+        gen = self.resolve_redirects(r, request, **kwargs)
 
         # Resolve redirects, if allowed.
         history = [resp for resp in gen] if allow_redirects else []

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1564,9 +1564,10 @@ class TestRequests:
 
     def test_manual_redirect_with_partial_body_read(self, httpbin):
         s = requests.Session()
-        r1 = s.get(httpbin('redirect/2'), allow_redirects=False, stream=True)
+        req = requests.Request('GET', httpbin('redirect/2')).prepare()
+        r1 = s.send(req, allow_redirects=False, stream=True)
         assert r1.is_redirect
-        rg = s.resolve_redirects(r1, stream=True)
+        rg = s.resolve_redirects(r1, req, stream=True)
 
         # read only the first eight bytes of the response body,
         # then follow the redirect
@@ -2239,7 +2240,7 @@ def test_requests_are_updated_each_time(httpbin):
     r0 = session.send(prep)
     assert r0.request.method == 'POST'
     assert session.calls[-1] == SendCall((r0.request,), {})
-    redirect_generator = session.resolve_redirects(r0)
+    redirect_generator = session.resolve_redirects(r0, prep)
     default_keyword_args = {
         'stream': False,
         'verify': True,


### PR DESCRIPTION
This will fix the build issue on the proposed/3.0.0 branch.

When the `resp` and `req` parameters were condensed into `response`, it had some unintentional effects on responses modified by hooks. The `req` parameter was the request prior to being sent and hooks being run. Since `handle_401` resends the request again with the Authorization header, using `response.request` continues to pass it on with every redirect.

Reverting this change is the simplest approach since it's mostly cosmetic. We could alternatively look into a more explicit removal of Authorization headers on redirects.