### PR TITLE
altered internal loops of how ``SessionRedirectMixin.resolve_redirect…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ Release History
   querying ``Response.is_redirect`` and ``Response.headers['location']``.
   Advanced users will be able to process malformed redirects more easily.
 
+- Altered how ``SessionRedirectMixin.resolve_redirects`` and ``Session.send``
+  process redirect history.
+
 2.13.0 (2017-01-24)
 +++++++++++++++++++
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -97,7 +97,7 @@ class SessionRedirectMixin(object):
                           verify=True, cert=None, proxies=None, **adapter_kwargs):
         """Receives a Response. Returns a generator of Responses."""
 
-        hist = [resp, ] # keep track of history; seed it with the original response
+        hist = [resp] # keep track of history; seed it with the original response
 
         url = self.get_redirect_target(resp)
         while url:


### PR DESCRIPTION
This is an idea for updating the `resolve_redirects` loop.  

The existing code was hard to untangle as variables get overwritten midway through the loop (`resp` switches between the previous and the next, which can be easy to miss).  It manages the `hist` by omitting the first request, appending the previous request, then shuffling some stuff around in a cleanup during the `send` method.

In this approach, populating the `hist` is moved down the loop so the current request is topmost on the stack.   The cleanup function is then simplified to just popping it off.

This passes all tests, but causes a slight undocumented API change -- the value of `request.history` changes, requiring a slightly different cleanup.  The only code that calls `resolve_redirects` is within `Session.send`, but I don't know if this would break any hooks.

anyways, I think this makes the block more straightforward as the "cleanup" function in `send` is simplified and the context of `resp` when appending the history doesn't change as much.  another approach I thought of was using inline comments or variable name changes to clearly note which is the "previous_request" in that loop.