### PR TITLE
properly handled failed seek

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -92,14 +92,16 @@ def super_len(o):
         else:
             if hasattr(o, 'seek') and total_length is None:
                 # StringIO and BytesIO have seek but no useable fileno
+                try:
+                    # seek to end of file
+                    o.seek(0, 2)
+                    total_length = o.tell()
 
-                # seek to end of file
-                o.seek(0, 2)
-                total_length = o.tell()
-
-                # seek back to current position to support
-                # partially read file-like objects
-                o.seek(current_position or 0)
+                    # seek back to current position to support
+                    # partially read file-like objects
+                    o.seek(current_position or 0)
+                except (OSError, IOError):
+                    total_length = 0
 
     if total_length is None:
         total_length = 0

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1546,7 +1546,7 @@ class TestRequests:
             def tell(self):
                 return 0
 
-            def seek(self, pos):
+            def seek(self, pos, whence=0):
                 raise OSError()
 
             def __iter__(self):


### PR DESCRIPTION
This is a minor bug in the way we're handling exceptions for `super_len` in `prepare_body`. The mocked `seek` method wasn't created with the optional `whence` parameter and was failing with a `TypeError` when called. A legacy exception block for the older version of `super_len` caught this and made it appear the test was passing.

This commit will wrap the seek->tell->seek process in the appropriate exceptions and fix the test.

I think there's two things that may need further discussion though. The first minor one being, we've been using `super_len` in `prepare_content_length` without this broad exception block from `prepare_body` for two releases without issue. I'm going to suggest we remove it from `prepare_body` because I don't think these exceptions can be raised from `super_len` any longer, except in cases we probably don't want them caught.

The second is, if we seek to the end of a file and fail on the `tell` or `seek` back to the original position, do we want to actually send the request? At that point, we'd probably want to raise an exception, right? This probably is something for 3.0.0 since it will be breaking, but wanted to address it before we merge this.