### PR TITLE
added docstring for response.ok property

### DIFF
--- a/requests/models.py
+++ b/requests/models.py
@@ -672,6 +672,7 @@ class Response(object):
 
     @property
     def ok(self):
+        """Returns true if :attr:`status_code` is 'OK'."""
         try:
             self.raise_for_status()
         except HTTPError:


### PR DESCRIPTION
Nothing much here, just added a docstring for `response.ok` property.

Took the docstring straight from the other methods to stay consistent.