### PR TITLE
Refactor Prepare Body

### DIFF
--- a/3.0-HISTORY.rst
+++ b/3.0-HISTORY.rst
@@ -1,6 +1,10 @@
 3.0.0 (2017-xx-xx)
 ++++++++++++++++++
 
+- Simplified logic for determining Content-Length and Transfer-Encoding.
+  Requests will now avoid setting both headers on the same request, and
+  raise an exception if this is done manually by a user.
+
 - Remove the HTTPProxyAuth class in favor of supporting proxy auth via
   the proxies parameter.
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -107,6 +107,10 @@ class RetryError(RequestException):
 class UnrewindableBodyError(RequestException):
     """Requests encountered an error when trying to rewind a body"""
 
+class ConflictingHeaderError(RequestException):
+    """Mutually exclusive request headers set"""
+
+
 # Warnings
 
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -104,11 +104,14 @@ class StreamConsumedError(RequestException, TypeError):
 class RetryError(RequestException):
     """Custom retries logic failed"""
 
+
 class UnrewindableBodyError(RequestException):
     """Requests encountered an error when trying to rewind a body"""
 
+
 class ConflictingHeaderError(RequestException):
     """Mutually exclusive request headers set"""
+
 
 class InvalidBodyError(RequestException, ValueError):
     """An invalid request body was specified"""

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -110,6 +110,8 @@ class UnrewindableBodyError(RequestException):
 class ConflictingHeaderError(RequestException):
     """Mutually exclusive request headers set"""
 
+class UnreachableCodeError(RequestException, RuntimeError):
+    """Unreachable code block reached"""
 
 # Warnings
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -110,8 +110,8 @@ class UnrewindableBodyError(RequestException):
 class ConflictingHeaderError(RequestException):
     """Mutually exclusive request headers set"""
 
-class UnreachableCodeError(RequestException, RuntimeError):
-    """Unreachable code block reached"""
+class InvalidBodyError(RequestException, ValueError):
+    """An invalid request body was specified"""
 
 # Warnings
 

--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -109,10 +109,6 @@ class UnrewindableBodyError(RequestException):
     """Requests encountered an error when trying to rewind a body"""
 
 
-class ConflictingHeaderError(RequestException):
-    """Mutually exclusive request headers set"""
-
-
 class InvalidBodyError(RequestException, ValueError):
     """An invalid request body was specified"""
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -527,7 +527,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
             else:
-                raise UnreachableCodeError("Non-null body must have length or be streamable")
+                raise InvalidBodyError("Non-null body must have length or be streamable")
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -526,6 +526,8 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
                 self.headers['Content-Length'] = builtin_str(length)
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
+            else:
+                assert False, "If body is not null, it must either have a length or be streamable"
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/models.py
+++ b/requests/models.py
@@ -527,7 +527,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             elif is_stream and not length:
                 self.headers['Transfer-Encoding'] = 'chunked'
             else:
-                assert False, "If body is not null, it must either have a length or be streamable"
+                raise UnreachableCodeError("Non-null body must have length or be streamable")
         elif (self.method not in ('GET', 'HEAD')) and (self.headers.get('Content-Length') is None):
             self.headers['Content-Length'] = '0'
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -881,9 +881,8 @@ def rewind_body(prepared_request):
         raise UnrewindableBodyError("Unable to rewind request body for redirect.")
 
 
-def determine_if_stream(data):
-    """Given data, determines if it should be sent as a stream.
-    """
+def is_stream(data):
+    """Given data, determines if it should be sent as a stream."""
     is_iterable = getattr(data, '__iter__', False)
-    is_io_type = not isinstance(data, (basestring, list, tuple, dict))
+    is_io_type = not isinstance(data, (basestring, list, tuple, collections.Mapping))
     return is_iterable and is_io_type

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -884,6 +884,6 @@ def rewind_body(prepared_request):
 def determine_if_stream(data):
     """Given data, determines if it should be sent as a stream.
     """
-    is_iterable = hasattr(data, '__iter__')
+    is_iterable = getattr(data, '__iter__', False)
     is_io_type = not isinstance(data, (basestring, list, tuple, dict))
     return is_iterable and is_io_type

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -865,6 +865,7 @@ def urldefragauth(url):
 
     return urlunparse((scheme, netloc, path, params, query, ''))
 
+
 def rewind_body(prepared_request):
     """Move file pointer back to its recorded starting position
     so it can be read again on redirect.
@@ -878,3 +879,11 @@ def rewind_body(prepared_request):
                                         "body for redirect.")
     else:
         raise UnrewindableBodyError("Unable to rewind request body for redirect.")
+
+
+def determine_if_stream(data):
+    """Given data, determines if it should be sent as a stream.
+    """
+    is_iterable = hasattr(data, '__iter__')
+    is_io_type = not isinstance(data, (basestring, list, tuple, dict))
+    return is_iterable and is_io_type

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -25,7 +25,7 @@ from requests.cookies import (
 from requests.exceptions import (
     ConnectionError, ConnectTimeout, InvalidScheme, InvalidURL,
     MissingScheme, ReadTimeout, Timeout, RetryError, TooManyRedirects,
-    ProxyError, InvalidHeader, UnrewindableBodyError, ConflictingHeaderError)
+    ProxyError, InvalidHeader, UnrewindableBodyError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin
@@ -1926,28 +1926,28 @@ class TestRequests:
 
     def test_chunked_upload_with_manually_set_content_length_header_raises_error(self, httpbin):
         """Ensure that if a user manually sets a content length header, when
-        the data is chunked, that a ConflictingHeaderError is raised.
+        the data is chunked, that an InvalidHeader error is raised.
         """
         data = (i for i in [b'a', b'b', b'c']) 
         url = httpbin('post')
-        with pytest.raises(ConflictingHeaderError):
+        with pytest.raises(InvalidHeader):
             r = requests.post(url, data=data, headers={'Content-Length': 'foo'})
 
     def test_content_length_with_manually_set_transfer_encoding_raises_error(self, httpbin):
         """Ensure that if a user manually sets a Transfer-Encoding header when
-        data is not chunked that an ConflictingHeaderError is raised.
+        data is not chunked that an InvalidHeader error is raised.
         """
         data = 'test data'
         url = httpbin('post')
-        with pytest.raises(ConflictingHeaderError):
+        with pytest.raises(InvalidHeader):
             r = requests.post(url, data=data, headers={'Transfer-Encoding': 'chunked'})
 
     def test_null_body_does_not_raise_error(self, httpbin):
         url = httpbin('post')
         try:
             requests.post(url, data=None)
-        except ConflictingHeaderError:
-            pytest.fail('ConflictingHeaderError raised.')
+        except InvalidHeader:
+            pytest.fail('InvalidHeader error raised unexpectedly.')
 
     def test_custom_redirect_mixin(self, httpbin):
         """Tests a custom mixin to overwrite ``get_redirect_target``.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1925,16 +1925,18 @@ class TestRequests:
         assert 'Content-Length' not in prepared_request.headers
 
     def test_chunked_upload_with_manually_set_content_length_header_raises_error(self, httpbin):
-        """Ensure that if a user manually sets a content length header when the data
-        is chunked that an ConflictingHeaderError is raised"""
-        data = (i for i in [b'a', b'b', b'c'])
+        """Ensure that if a user manually sets a content length header, when
+        the data is chunked, that a ConflictingHeaderError is raised.
+        """
+        data = (i for i in [b'a', b'b', b'c']) 
         url = httpbin('post')
         with pytest.raises(ConflictingHeaderError):
             r = requests.post(url, data=data, headers={'Content-Length': 'foo'})
 
     def test_content_length_with_manually_set_transfer_encoding_raises_error(self, httpbin):
-        """Ensure that if a user manually sets a Transfer-Encoding header when data is not chunked
-        that an ConflictingHeaderError is raised"""
+        """Ensure that if a user manually sets a Transfer-Encoding header when
+        data is not chunked that an ConflictingHeaderError is raised.
+        """
         data = 'test data'
         url = httpbin('post')
         with pytest.raises(ConflictingHeaderError):
@@ -1945,7 +1947,7 @@ class TestRequests:
         try:
             requests.post(url, data=None)
         except ConflictingHeaderError:
-            pytest.fail('ConflictingHeaderError raised')
+            pytest.fail('ConflictingHeaderError raised.')
 
     def test_custom_redirect_mixin(self, httpbin):
         """Tests a custom mixin to overwrite ``get_redirect_target``.

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -25,7 +25,7 @@ from requests.cookies import (
 from requests.exceptions import (
     ConnectionError, ConnectTimeout, InvalidScheme, InvalidURL,
     MissingScheme, ReadTimeout, Timeout, RetryError, TooManyRedirects,
-    ProxyError, InvalidHeader, UnrewindableBodyError)
+    ProxyError, InvalidHeader, UnrewindableBodyError, ConflictingHeaderError)
 from requests.models import PreparedRequest
 from requests.structures import CaseInsensitiveDict
 from requests.sessions import SessionRedirectMixin
@@ -1923,6 +1923,29 @@ class TestRequests:
         prepared_request = r.prepare()
         assert 'Transfer-Encoding' in prepared_request.headers
         assert 'Content-Length' not in prepared_request.headers
+
+    def test_chunked_upload_with_manually_set_content_length_header_raises_error(self, httpbin):
+        """Ensure that if a user manually sets a content length header when the data
+        is chunked that an ConflictingHeaderError is raised"""
+        data = (i for i in [b'a', b'b', b'c'])
+        url = httpbin('post')
+        with pytest.raises(ConflictingHeaderError):
+            r = requests.post(url, data=data, headers={'Content-Length': 'foo'})
+
+    def test_content_length_with_manually_set_transfer_encoding_raises_error(self, httpbin):
+        """Ensure that if a user manually sets a Transfer-Encoding header when data is not chunked
+        that an ConflictingHeaderError is raised"""
+        data = 'test data'
+        url = httpbin('post')
+        with pytest.raises(ConflictingHeaderError):
+            r = requests.post(url, data=data, headers={'Transfer-Encoding': 'chunked'})
+
+    def test_null_body_does_not_raise_error(self, httpbin):
+        url = httpbin('post')
+        try:
+            requests.post(url, data=None)
+        except ConflictingHeaderError:
+            pytest.fail('ConflictingHeaderError raised')
 
     def test_custom_redirect_mixin(self, httpbin):
         """Tests a custom mixin to overwrite ``get_redirect_target``.


### PR DESCRIPTION
This PR supersedes #3338 with the branch brought up to date, as well as a few minor changes, including logic tweaks based on updates to `super_len` since the original PR.

This will forcibly prevent the transmission of headers that include both Content-Length and Transfer-Encoding, as well as simplify redundant code we use for both `prepare_content_length` and `prepare_body`. All the credit here goes to @davidsoncasey, the original creator of this PR.