### PR TITLE
remove redundant exception declaration

### DIFF
--- a/requests/exceptions.py
+++ b/requests/exceptions.py
@@ -85,10 +85,6 @@ class InvalidHeader(RequestException, ValueError):
     """The header value provided was somehow invalid."""
 
 
-class InvalidHeader(RequestException, ValueError):
-    """The header value provided was somehow invalid."""
-
-
 class ChunkedEncodingError(RequestException):
     """The server declared chunked encoding but sent an invalid chunk."""
 


### PR DESCRIPTION
Looks like a duplicate copy of this exception was added at some point in a previous merge from master. Preferably hold off on merging this until #3897 is merged to avoid rebasing those commits again.