### PR TITLE
HTTPAdapter.send() timeout defaults

### DIFF
--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -420,14 +420,11 @@ class HTTPAdapter(BaseAdapter):
                 raise ValueError(err)
         elif isinstance(timeout, TimeoutSauce):
             pass
-        elif timeout is not None:
+        else:
             timeout = TimeoutSauce(connect=timeout, read=timeout)
 
         try:
             if not chunked:
-                kwargs = {}
-                if timeout is not None:
-                    kwargs['timeout'] = timeout
                 resp = conn.urlopen(
                     method=request.method,
                     url=url,
@@ -438,7 +435,7 @@ class HTTPAdapter(BaseAdapter):
                     preload_content=False,
                     decode_content=False,
                     retries=self.max_retries,
-                    **kwargs
+                    timeout=timeout
                 )
 
             # Send the request.

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -408,7 +408,6 @@ class HTTPAdapter(BaseAdapter):
 
         chunked = not (request.body is None or 'Content-Length' in request.headers)
 
-        
         if isinstance(timeout, tuple):
             try:
                 connect, read = timeout

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -409,9 +409,7 @@ class HTTPAdapter(BaseAdapter):
         chunked = not (request.body is None or 'Content-Length' in request.headers)
 
         
-        if isinstance(timeout, TimeoutSauce):
-            pass
-        elif isinstance(timeout, tuple):
+        if isinstance(timeout, tuple):
             try:
                 connect, read = timeout
                 timeout = TimeoutSauce(connect=connect, read=read)
@@ -421,6 +419,8 @@ class HTTPAdapter(BaseAdapter):
                        "timeout tuple, or a single float to set "
                        "both timeouts to the same value".format(timeout))
                 raise ValueError(err)
+        elif isinstance(timeout, TimeoutSauce):
+            pass
         elif timeout is not None:
             timeout = TimeoutSauce(connect=timeout, read=timeout)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -33,7 +33,7 @@ from requests.hooks import default_hooks
 
 from .compat import StringIO, u
 from .utils import override_environ
-from requests.packages.urllib3.util import Timeout
+from requests.packages.urllib3.util import Timeout as Urllib3Timeout
 
 # Requests to this URL should always fail with a connection timeout (nothing
 # listening on that port)
@@ -2017,7 +2017,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         'timeout', (
             None,
-            Timeout(connect=None, read=None)
+            Urllib3Timeout(connect=None, read=None)
         ))
     def test_none_timeout(self, httpbin, timeout):
         """Check that you can set None as a valid timeout value.
@@ -2034,7 +2034,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         'timeout', (
             (None, 0.1),
-            Timeout(connect=None, read=0.1)
+            Urllib3Timeout(connect=None, read=0.1)
         ))
     def test_read_timeout(self, httpbin, timeout):
         try:
@@ -2046,7 +2046,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         'timeout', (
             (0.1, None),
-            Timeout(connect=0.1, read=None)
+            Urllib3Timeout(connect=0.1, read=None)
         ))
     def test_connect_timeout(self, timeout):
         try:
@@ -2059,7 +2059,7 @@ class TestTimeout:
     @pytest.mark.parametrize(
         'timeout', (
             (0.1, 0.1),
-            Timeout(connect=0.1, read=0.1)
+            Urllib3Timeout(connect=0.1, read=0.1)
         ))
     def test_total_timeout_connect(self, timeout):
         try:


### PR DESCRIPTION
This PR allows to use urllib3 ``Timeout`` objects as ``timeout`` argument in ``HTTPAdapter.send()``.

Besides it omits the ``timeout`` argument when calling ``conn.urlopen()`` if ``HTTPAdapter.send()`` is called without a timeout. This allows setting a default timeout at connection pool level:
`adapter.poolmanager.connection_pool_kw['timeout'] = urllib3.Timeout(...)`