### PR TITLE
fix unicode decode error on py2 when handling redirect without scheme

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -179,4 +179,4 @@ Patches and Suggestions
 - Matt Kohl (`@mattkohl <https://github.com/mattkohl>`_)
 - Jonathan Vanasco (`@jvanasco <https://github.com/jvanasco>`_)
 - David Fontenot (`@davidfontenot <https://github.com/davidfontenot>`_)
-
+- Shmuel Amar (`@shmuelamar <https://github.com/shmuelamar>`_)

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -122,7 +122,7 @@ class SessionRedirectMixin(object):
             # Handle redirection without scheme (see: RFC 1808 Section 4)
             if url.startswith('//'):
                 parsed_rurl = urlparse(resp.url)
-                url = '%s:%s' % (parsed_rurl.scheme, url)
+                url = '%s:%s' % (to_native_string(parsed_rurl.scheme), url)
 
             # The scheme should be lower case...
             parsed = urlparse(url)


### PR DESCRIPTION
as discussed on #3959 , fix the UnicodeDecodeError happening because implicit decoding of str string into unicode while using python2.

This issue happens when handling redirection without scheme  (i.e. Location: //URL) on python2 and only if the location is unicode.

First time applying a PR on GitHub so let me know if there is something I can do to make it better :).

Thanks,
Shmulik