### PR TITLE
Allowing users to override the default agent using env variable

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -685,10 +685,12 @@ def select_proxy(url, proxies):
 def default_user_agent(name="python-requests"):
     """
     Return a string representing the default user agent.
+    Allows overriding the default user agent using the REQUESTS_DEFAULT_USER_AGENT
+    environment variable.
 
     :rtype: str
     """
-    return '%s/%s' % (name, __version__)
+    return os.environ.get('REQUESTS_DEFAULT_USER_AGENT', '%s/%s' % (name, __version__))
 
 
 def default_headers():


### PR DESCRIPTION
We need to override the default user agent that requests uses. I think its ok to allow overriding the default user agent using environment variables.

I didn't find other options (except monkey patching default_user_agent function in utils), maybe this can help other users as well.