### PR TITLE
Use sys_platform instead of platform_system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     extras_require={
         'security': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
-        'socks:platform_system == "Windows" and python_version<"3.3"': ['win_inet_pton'],
+        'socks:sys_platform == "win32" and python_version<"3.3"': ['win_inet_pton'],
     },
 )
 


### PR DESCRIPTION
This is more compatible as a marker and so will break fewer people. Potentially resolves #4006.