### PR TITLE
Remove range operators from markers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     extras_require={
         'security': ['pyOpenSSL>=0.14', 'cryptography>=1.3.4', 'idna>=2.0.0'],
         'socks': ['PySocks>=1.5.6, !=1.5.7'],
-        'socks:sys_platform == "win32" and python_version<"3.3"': ['win_inet_pton'],
+        'socks:sys_platform == "win32" and (python_version == "2.7" or python_version == "2.6")': ['win_inet_pton'],
     },
 )
 


### PR DESCRIPTION
Resolves #4013.

It turns out that older setuptools were pretty stupid and couldn't handle range operators, but they *can* handle parentheses and the word "or". So let's do that instead.