### PR TITLE
remove old test_requests.py listing from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE NOTICE HISTORY.rst test_requests.py requests/cacert.pem
+include README.rst LICENSE NOTICE HISTORY.rst requests/cacert.pem


### PR DESCRIPTION
This is a trivial fix to address a warning pointed out in #4012.

`test_requests.py` was moved from the top level directory into the `tests` directory in 2.10.0 but the MANIFEST.in wasn't updated afterwards. Installing from setup.py produces a warning (`no files found matching 'test_requests.py'`). This patch will remove the unneeded listing and keep the warning from cluttering stderr.