### PR TITLE
Add setup.cfg to declare wheel as universal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ idna:
 
 publish:
 	pip install 'twine>=1.5.0'
-	python setup.py sdist
-	python setup.py bdist_wheel --universal
+	python setup.py sdist bdist_wheel
 	twine upload dist/*
 	rm -fr build dist .egg requests.egg-info
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
As the project is pure Python, a built wheel should always be universal,
so define in the project globally. Can remove --universal command from
Makefile.

See:

http://pythonwheels.com/