### PR TITLE
Persist Session-level CookiePolicy

### DIFF
--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -412,7 +412,7 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
 
     def copy(self):
         """Return a copy of this RequestsCookieJar."""
-        new_cj = RequestsCookieJar()
+        new_cj = RequestsCookieJar(self._policy)
         new_cj.update(self)
         return new_cj
 

--- a/requests/sessions.py
+++ b/requests/sessions.py
@@ -16,7 +16,8 @@ from datetime import timedelta
 from .auth import _basic_auth_str
 from .compat import cookielib, OrderedDict, urljoin, urlparse, is_py3, str
 from .cookies import (
-    cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar, merge_cookies)
+    cookiejar_from_dict, extract_cookies_to_jar, RequestsCookieJar,
+    merge_cookies, _copy_cookie_jar)
 from .models import Request, PreparedRequest, DEFAULT_REDIRECT_LIMIT
 from .hooks import default_hooks, dispatch_hook
 from ._internal_utils import to_native_string
@@ -425,8 +426,8 @@ class Session(SessionRedirectMixin):
             cookies = cookiejar_from_dict(cookies)
 
         # Merge with session cookies
-        merged_cookies = merge_cookies(
-            merge_cookies(RequestsCookieJar(), self.cookies), cookies)
+        session_cookies = _copy_cookie_jar(self.cookies)
+        merged_cookies = merge_cookies(session_cookies, cookies)
 
         # Set environment's basic authentication if not explicitly set.
         auth = request.auth


### PR DESCRIPTION
This is a followup for #3463, but refactored without the persistence flag which makes this a breaking change. Currently, Requests silently throws away any cookie policies set on a CookieJar as noted in #3416. This patch will preserve the CookiePolicy set on a session-level CookieJar for both redirected and subsequent requests.

The only caveat here is this won't work for a non-RequestsCookieJar since the policy isn't exposed publicly. We may want to add some documentation about this caveat but given the rarity of this case, the information in the issue tracker may be sufficient.