### PR TITLE
More Verbose Execption Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.cache/
 MANIFEST
 coverage.xml
 nosetests.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .coverage
-.cache/
 MANIFEST
 coverage.xml
 nosetests.xml

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -493,13 +493,12 @@ class HTTPAdapter(BaseAdapter):
                 # TODO: Remove this in 3.0.0: see #2811
                 if not isinstance(e.reason, NewConnectionError):
                     raise ConnectTimeout(e, request=request)
-
-            if isinstance(e.reason, ResponseError):
+            elif isinstance(e.reason, ResponseError):
                 raise RetryError(e, request=request)
-
-            if isinstance(e.reason, _ProxyError):
+            elif isinstance(e.reason, _ProxyError):
                 raise ProxyError(e, request=request)
-
+            elif isinstance(e.reason,RetryError):
+                raise RetryError(e, request=request)
             raise ConnectionError(e, request=request)
 
         except ClosedPoolError as e:

--- a/requests/adapters.py
+++ b/requests/adapters.py
@@ -493,11 +493,14 @@ class HTTPAdapter(BaseAdapter):
                 # TODO: Remove this in 3.0.0: see #2811
                 if not isinstance(e.reason, NewConnectionError):
                     raise ConnectTimeout(e, request=request)
-            elif isinstance(e.reason, ResponseError):
+
+            if isinstance(e.reason, ResponseError):
                 raise RetryError(e, request=request)
-            elif isinstance(e.reason, _ProxyError):
+
+            if isinstance(e.reason, _ProxyError):
                 raise ProxyError(e, request=request)
-            elif isinstance(e.reason,RetryError):
+
+            if isinstance(e.reason,RetryError):
                 raise RetryError(e, request=request)
             raise ConnectionError(e, request=request)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -518,8 +518,7 @@ class TestRequests:
         ))
     def test_errors(self, url, exception):
         with pytest.raises(exception):
-            r = requests.get(url, timeout=1)
-            assert r.exception == exception
+            requests.get(url, timeout=1)
 
     def test_proxy_error(self):
         # any proxy related error (address resolution, no route to host, etc) should result in a ProxyError


### PR DESCRIPTION
So I tried to add more verbose exception handling without breaking current functionality (this feels really hacky).  It seems to me that it may be pertinent to break these out and not raise a connection error for each request (as denoted in : https://github.com/kennethreitz/requests/issues/2876)

In the current implementation, a ConnectionError is raised for each call, as well as a max retries message.  It seems like the max retries message error should either be removed or made as more of a general string response statement.  This general string response is here:
https://github.com/kennethreitz/requests/blob/master/requests/adapters.py#L503

Doing so would require removing that line and adding explicit responses within that max retry block, but this might break current functionality if people are depending on the response from requests to make other decisions.

Looking forward to a discussion on this topic.
