### PR TITLE
Add an enhancement for transforamtion between dict and cookiejar.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -181,3 +181,4 @@ Patches and Suggestions
 - Jonathan Vanasco (`@jvanasco <https://github.com/jvanasco>`_)
 - David Fontenot (`@davidfontenot <https://github.com/davidfontenot>`_)
 - Shmuel Amar (`@shmuelamar <https://github.com/shmuelamar>`_)
+- SenbinYu (`@justdoit0823 <https://github.com/justdoit0823>`_)

--- a/requests/cookies.py
+++ b/requests/cookies.py
@@ -513,7 +513,16 @@ def cookiejar_from_dict(cookie_dict, cookiejar=None, overwrite=True):
         names_from_jar = [cookie.name for cookie in cookiejar]
         for name in cookie_dict:
             if overwrite or (name not in names_from_jar):
-                cookiejar.set_cookie(create_cookie(name, cookie_dict[name]))
+                cookie_data = cookie_dict[name]
+                if isinstance(cookie_data, dict):
+                    cookie_name = cookie_data.pop('name')
+                    cookie_val = cookie_data.pop('value')
+                    cookie_obj = create_cookie(
+                        cookie_name, cookie_val, **cookie_data)
+                else:
+                    cookie_obj = create_cookie(name, cookie_data)
+
+                cookiejar.set_cookie(cookie_obj)
 
     return cookiejar
 

--- a/requests/utils.py
+++ b/requests/utils.py
@@ -38,6 +38,10 @@ NETRC_FILES = ('.netrc', '_netrc')
 
 DEFAULT_CA_BUNDLE_PATH = certs.where()
 
+COOKIE_ATTRS = (
+    'version', 'name', 'value', 'port', 'domain', 'path', 'secure', 'expires',
+    'discard', 'comment', 'comment_url', 'rfc2109')
+
 
 if platform.system() == 'Windows':
     # provide a proxy_bypass version on Windows without DNS lookups
@@ -361,17 +365,32 @@ def unquote_header_value(value, is_filename=False):
     return value
 
 
-def dict_from_cookiejar(cj):
+def dict_from_cookiejar(cj, with_cookie_attr=False):
     """Returns a key/value dictionary from a CookieJar.
 
     :param cj: CookieJar object to extract cookies from.
+    :param with_cookie_attr: a boolean specifies whether returns more attrs.
     :rtype: dict
     """
 
     cookie_dict = {}
 
     for cookie in cj:
-        cookie_dict[cookie.name] = cookie.value
+        if not with_cookie_attr:
+            cookie_dict[cookie.name] = cookie.value
+            continue
+
+        cookie_data = {}
+        for attr in COOKIE_ATTRS:
+            attr_val = getattr(cookie, attr, None)
+            if attr_val is not None:
+                cookie_data[attr] = attr_val
+
+        cookie_rest = getattr(cookie, '_rest', None)
+        if cookie_rest:
+            cookie_data['rest'] = cookie_rest
+
+        cookie_dict[cookie.name] = cookie_data
 
     return cookie_dict
 


### PR DESCRIPTION
When using dict_from_cookiejar, I can only get name and value from cookie object, otherwise other cookie attributes are lost. So I want to make an enhancement about two methods dict_from_cookiejar and cookiejar_from_dict, which can be more flexible and safe to do cookie transformation and persistence like the following code.

```
import requests
from requests.utils import dict_from_cookiejar

res = requests.get('https://github.com/justdoit0823/notes')

dict_from_cookiejar(res.cookies)

dict_from_cookiejar(res.cookies, with_cookie_attr=True)
```

And the output:

```
#  with_cookie_attr is False
{'_gh_sess': 'somevalue', 'logged_in': 'no'}

#  with_cookie_attr is True
{'_gh_sess': {'discard': True,
  'domain': 'github.com',
  'name': '_gh_sess',
  'path': '/',
  'rest': {'HttpOnly': None},
  'rfc2109': False,
  'secure': True,
  'value': 'somevalue',
  'version': 0},
 'logged_in': {'discard': False,
  'domain': '.github.com',
  'expires': 2126671044,
  'name': 'logged_in',
  'path': '/',
  'rest': {'HttpOnly': None},
  'rfc2109': False,
  'secure': True,
  'value': 'no',
  'version': 0}}
```