### PR TITLE
Fix regression in API caused by commit 85400d8d6751071ef78f042d1efa72…

### DIFF
--- a/requests/utils.py
+++ b/requests/utils.py
@@ -684,7 +684,7 @@ def should_bypass_proxies(url, no_proxy):
     return False
 
 
-def get_environ_proxies(url, no_proxy):
+def get_environ_proxies(url, no_proxy=None):
     """
     Return a dict of environment proxies.
 


### PR DESCRIPTION
…bdcf76cc0e

  - The added optional parameter changes API and should default to None

    This utility call is used by for example requestbuilder package directly
    which breaks because it passes only one argument to the function as it
    used to be.