### PR TITLE
Disable pytest messing with warnings.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst LICENSE NOTICE HISTORY.rst requests/cacert.pem
+include README.rst LICENSE NOTICE HISTORY.rst pytest.ini requests/cacert.pem
 recursive-include tests *.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ packages = [
 requires = []
 test_requirements = ['pytest>=2.8.0', 'pytest-httpbin==0.0.7', 'pytest-cov', 'pytest-mock']
 
-with open('requests/__init__.py', 'r') as fd:
+with open('requests/__init__.py', 'r', 'utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 


### PR DESCRIPTION
We may be able to remove this if pytest resolves pytest-dev/pytest#2430, but until that point we need to turn the old behaviour back on.