### PR TITLE
Stop relying on a regexp for version parsing

### DIFF
--- a/requests/__about__.py
+++ b/requests/__about__.py
@@ -1,0 +1,7 @@
+title = 'requests'
+version = '2.14.2'
+build = 0x021402
+author = 'Kenneth Reitz'
+license = 'Apache 2.0'
+copyright = 'Copyright 2017 Kenneth Reitz'
+cake = u'✨ 🍰 ✨ Thanks for using my software. It means the world to me.  --kennethreitz'

--- a/requests/__about__.py
+++ b/requests/__about__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 title = 'requests'
 version = '2.14.2'
 build = 0x021402

--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -40,13 +40,15 @@ is at <http://python-requests.org>.
 :license: Apache 2.0, see LICENSE for more details.
 """
 
-__title__ = 'requests'
-__version__ = '2.14.2'
-__build__ = 0x021402
-__author__ = 'Kenneth Reitz'
-__license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2017 Kenneth Reitz'
-__cake__ = u'✨ 🍰 ✨ Thanks for using my software. It means the world to me. --kennethreitz'
+from .__about__ import (
+    title as __title__,
+    version as __version__,
+    build as __build__,
+    author as __author__,
+    license as __license__,
+    copyright as __copyright__,
+    cake as __cake__,
+)
 
 # Attempt to enable urllib3's SNI support, if possible
 try:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
+import io
 import os
-import re
 import sys
 
 from codecs import open
@@ -51,24 +51,24 @@ packages = [
 requires = []
 test_requirements = ['pytest>=2.8.0', 'pytest-httpbin==0.0.7', 'pytest-cov', 'pytest-mock']
 
-with open('requests/__init__.py', 'r', 'utf-8') as fd:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
-
-if not version:
-    raise RuntimeError('Cannot find version information')
-
 with open('README.rst', 'r', 'utf-8') as f:
     readme = f.read()
 with open('HISTORY.rst', 'r', 'utf-8') as f:
     history = f.read()
 
+metadata = {}
+with io.open('requests/__about__.py', encoding='utf-8') as f:
+    exec(f.read(), metadata)
+
+if not metadata['version']:
+    raise RuntimeError('Cannot find version information')
+
 setup(
     name='requests',
-    version=version,
+    version=metadata['version'],
     description='Python HTTP for Humans.',
     long_description=readme + '\n\n' + history,
-    author='Kenneth Reitz',
+    author=metadata['author'],
     author_email='me@kennethreitz.com',
     url='http://python-requests.org',
     packages=packages,
@@ -76,7 +76,7 @@ setup(
     package_dir={'requests': 'requests'},
     include_package_data=True,
     install_requires=requires,
-    license='Apache 2.0',
+    license=metadata['license'],
     zip_safe=False,
     classifiers=(
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Move all of our metadata into `requests/__about__.py` while keeping a
backwards compatible aliasing of metadata attributes. Also use this to
specify metadata in our setup.py

Closes #4057 

---

For what it's worth, I based this off of [pypa/packaging](https://github.com/pypa/packaging/blob/master/setup.py)