### PR TITLE
Fixed sending objects with no .read and with length

### DIFF
--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -727,6 +727,35 @@ class TestRequests:
         assert post2.status_code == 200
         assert post2.json()['data'] == 'st'
 
+    def test_POSTBIN_WITH_ITER(self, httpbin):
+
+        class TestIteratorWithLength(object):
+            def __init__(self, data):
+                self.data = data.encode()
+                self.length = len(self.data)
+                self.itersize = 2**20
+
+            def __len__(self):
+                return self.length
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self.data:
+                    ret = self.data[:self.itersize]
+                    self.data = self.data[self.itersize:]
+                    return ret
+                else:
+                    raise StopIteration()
+
+            next = __next__
+
+        test = TestIteratorWithLength('test')
+        post1 = requests.post(httpbin('post'), data=test)
+        assert post1.status_code == 200
+        assert post1.json()['data'] == 'test'
+
     def test_POSTBIN_GET_POST_FILES_WITH_DATA(self, httpbin):
 
         url = httpbin('post')


### PR DESCRIPTION
This is a bug fix, because sending such an object currently will cause an exception:
```python
  File "test.py", line 81, in client
    r = session.post(url, data=DataWithoutLength(a)).text
  File "/Users/icebreak/source/requestssux/requests/requests/sessions.py", line 572, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/Users/icebreak/source/requestssux/requests/requests/sessions.py", line 524, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/icebreak/source/requestssux/requests/requests/sessions.py", line 637, in send
    r = adapter.send(request, **kwargs)
  File "/Users/icebreak/source/requestssux/requests/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/Users/icebreak/source/requestssux/.venv2/lib/python2.7/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/Users/icebreak/source/requestssux/.venv2/lib/python2.7/site-packages/urllib3/connectionpool.py", line 354, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/Users/icebreak/miniconda2/lib/python2.7/httplib.py", line 1042, in request
    self._send_request(method, url, body, headers)
  File "/Users/icebreak/miniconda2/lib/python2.7/httplib.py", line 1082, in _send_request
    self.endheaders(body)
  File "/Users/icebreak/miniconda2/lib/python2.7/httplib.py", line 1038, in endheaders
    self._send_output(message_body)
  File "/Users/icebreak/miniconda2/lib/python2.7/httplib.py", line 886, in _send_output
    self.send(message_body)
  File "/Users/icebreak/miniconda2/lib/python2.7/httplib.py", line 858, in send
    self.sock.sendall(data)
  File "/Users/icebreak/miniconda2/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
TypeError: sendall() argument 1 must be convertible to a buffer, not DataWithoutLength
```
The patch makes sure that it will only fix this specific instance.