### PR TITLE
Lock pytest-httpbin to <1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test:
 	# This runs all of the tests, on both Python 2 and Python 3.
 	detox
 ci:
+	python -m pip freeze
 	pipenv run py.test -n 8 --boxed --junitxml=report.xml
 
 test-readme:

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ docutils = "*"
 "flake8" = "*"
 tox = "*"
 detox = "*"
-httpbin = ">=0.7.0"
+httpbin = ">=0.7.0,<1.0"
 
 [packages]
 "e1839a8" = {path = ".", editable = true, extras = ["socks"]}


### PR DESCRIPTION
[pytest-httpbin](https://github.com/kevin1024/pytest-httpbin) release 1.0.0 updated the `subjectAltName` field to the certificate which our unit tests assume doesn't have an IP Address entry in order to test warning generation.  [Changelog for 1.0.0 even mentions this breakage in our unit tests.](https://github.com/kevin1024/pytest-httpbin/commit/be3c3205972195ca632949ed7af1dc7086cb7899)