### PR TITLE
Allow urllib3 1.25.x

### DIFF
--- a/requests/__init__.py
+++ b/requests/__init__.py
@@ -57,10 +57,10 @@ def check_compatibility(urllib3_version, chardet_version):
     # Check urllib3 for compatibility.
     major, minor, patch = urllib3_version  # noqa: F811
     major, minor, patch = int(major), int(minor), int(patch)
-    # urllib3 >= 1.21.1, <= 1.24
+    # urllib3 >= 1.21.1, <= 1.25
     assert major == 1
     assert minor >= 21
-    assert minor <= 24
+    assert minor <= 25
 
     # Check chardet for compatibility.
     major, minor, patch = chardet_version.split('.')[:3]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ packages = ['requests']
 requires = [
     'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.9',
-    'urllib3>=1.21.1,<1.25',
+    'urllib3>=1.21.1,<1.26',
     'certifi>=2017.4.17'
 
 ]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ packages = ['requests']
 requires = [
     'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.9',
-    'urllib3>=1.21.1,<1.26',
+    'urllib3>=1.21.1,<1.26,!=1.25',
     'certifi>=2017.4.17'
 
 ]


### PR DESCRIPTION
1.25.x will include a fix for `CVE-2019-11236`

https://github.com/urllib3/urllib3/issues/1553#issuecomment-484213670