### PR TITLE
fix: CRLF injection in urllib3 - bump its version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ packages = ['requests']
 requires = [
     'chardet>=3.0.2,<3.1.0',
     'idna>=2.5,<2.9',
-    'urllib3>=1.21.1,<1.25',
+    'urllib3>=1.25.0,<1.26',
     'certifi>=2017.4.17'
 
 ]


### PR DESCRIPTION
https://app.snyk.io/vuln/SNYK-PYTHON-URLLIB3-174323 (CVE-2019-11236) is CRLF injection a vulnerability in the urllib3 library.
This PR bumps its version.
This might not be directly related to requests, but would forbid projects using requests from using a fixed version of `urllib3`