### PR TITLE
Print the type of the password instead of the password itself

### DIFF
--- a/requests/auth.py
+++ b/requests/auth.py
@@ -50,7 +50,7 @@ def _basic_auth_str(username, password):
             "Non-string passwords will no longer be supported in Requests "
             "3.0.0. Please convert the object you've passed in ({!r}) to "
             "a string or bytes object in the near future to avoid "
-            "problems.".format(password),
+            "problems.".format(type(password)),
             category=DeprecationWarning,
         )
         password = str(password)


### PR DESCRIPTION
Hello,

Although providing a non-string password would be very rear, it would be better the value of the password (even if it is incorrectly set) to not take part in the warning message.

Regards 