### PR TITLE
Fix GitHub links

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -762,9 +762,9 @@ documentation](https://requests.readthedocs.io/en/latest/community/release-proce
 **Features and Improvements**
 
 -   Add sha256 fingerprint support.
-    ([shazow/urllib3\#540](https://github.com/shazow/urllib3/pull/540))
+    ([urllib3/urllib3\#540](https://github.com/urllib3/urllib3/pull/540))
 -   Improve the performance of headers.
-    ([shazow/urllib3\#544](https://github.com/shazow/urllib3/pull/544))
+    ([urllib3/urllib3\#544](https://github.com/urllib3/urllib3/pull/544))
 
 **Bugfixes**
 
@@ -780,19 +780,19 @@ documentation](https://requests.readthedocs.io/en/latest/community/release-proce
     authentication challenges provides both auth and auth-int
     qop-values. (\#2408)
 -   Fix a socket leak.
-    ([shazow/urllib3\#549](https://github.com/shazow/urllib3/pull/549))
+    ([urllib3/urllib3\#549](https://github.com/urllib3/urllib3/pull/549))
 -   Fix multiple `Set-Cookie` headers properly.
-    ([shazow/urllib3\#534](https://github.com/shazow/urllib3/pull/534))
+    ([urllib3/urllib3\#534](https://github.com/urllib3/urllib3/pull/534))
 -   Disable the built-in hostname verification.
-    ([shazow/urllib3\#526](https://github.com/shazow/urllib3/pull/526))
+    ([urllib3/urllib3\#526](https://github.com/urllib3/urllib3/pull/526))
 -   Fix the behaviour of decoding an exhausted stream.
-    ([shazow/urllib3\#535](https://github.com/shazow/urllib3/pull/535))
+    ([urllib3/urllib3\#535](https://github.com/urllib3/urllib3/pull/535))
 
 **Security**
 
 -   Pulled in an updated `cacert.pem`.
 -   Drop RC4 from the default cipher list.
-    ([shazow/urllib3\#551](https://github.com/shazow/urllib3/pull/551))
+    ([urllib3/urllib3\#551](https://github.com/urllib3/urllib3/pull/551))
 
 2.5.1 (2014-12-23)
 ------------------
@@ -1253,7 +1253,7 @@ This is not a backwards compatible change.
 -------------------
 
 -   Removal of Requests.async in favor of
-    [grequests](https://github.com/kennethreitz/grequests)
+    [grequests](https://github.com/spyoungtech/grequests)
 -   Allow disabling of cookie persistence.
 -   New implementation of safe\_mode
 -   cookies.get now supports default argument

--- a/docs/community/recommended.rst
+++ b/docs/community/recommended.rst
@@ -59,4 +59,4 @@ Betamax
 `Betamax`_ records your HTTP interactions so the NSA does not have to.
 A VCR imitation designed only for Python-Requests.
 
-.. _betamax: https://github.com/sigmavirus24/betamax
+.. _betamax: https://github.com/betamaxpy/betamax

--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -1006,7 +1006,7 @@ library to use SSLv3::
                 block=block, ssl_version=ssl.PROTOCOL_SSLv3)
 
 .. _`described here`: https://www.kennethreitz.org/essays/the-future-of-python-http
-.. _`urllib3`: https://github.com/shazow/urllib3
+.. _`urllib3`: https://github.com/urllib3/urllib3
 
 .. _blocking-or-nonblocking:
 
@@ -1025,7 +1025,7 @@ out there that combine Requests with one of Python's asynchronicity frameworks.
 Some excellent examples are `requests-threads`_, `grequests`_, `requests-futures`_, and `httpx`_.
 
 .. _`requests-threads`: https://github.com/requests/requests-threads
-.. _`grequests`: https://github.com/kennethreitz/grequests
+.. _`grequests`: https://github.com/spyoungtech/grequests
 .. _`requests-futures`: https://github.com/ross/requests-futures
 .. _`httpx`: https://github.com/encode/httpx
 


### PR DESCRIPTION
All of these links now redirect to a repo under a different GitHub user account.

I don't know whether you want to update the changelog or leave it as it was at the time, but I'm happy to amend the PR to remove these edits if you prefer to leave `HISTORY.md` untouched.